### PR TITLE
[ALL] setting: PR 생성 및 리뷰 시 디스코드 알림 구현

### DIFF
--- a/.github/workflows/discord-pull-request-comment.yml
+++ b/.github/workflows/discord-pull-request-comment.yml
@@ -23,6 +23,7 @@ jobs:
           PR_TITLE='${{ github.event.pull_request.title }}'
           PR_AUTHOR='${{ github.event.pull_request.user.login }}'
           REVIEWER='${{ github.event.review.user.login }}'
+          WEBHOOK_URL=${{ secrets.DISCORD_WEBHOOK_URL }}
 
           REVIEWER_DISCORD_ID='${{ env[github.event.review.user.id] }}'
           AUTHOR_DISCORD_ID='${{ env[github.event.pull_request.user.id] }}'

--- a/.github/workflows/discord-pull-request-comment.yml
+++ b/.github/workflows/discord-pull-request-comment.yml
@@ -1,0 +1,76 @@
+name: Discord Notification on Pull Request
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+env:
+  'bianbbc87': '874203782391660554'
+  'chysis': '243991296060948491'
+  'onegood07': '674195406107967498'
+  'toychip': '534083612572909578'
+  'zelkovaria': '905293004322005043'
+
+jobs:
+  notify-on-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify on PR Review
+        run: |
+          echo "Notify on Discord"
+
+          PR_URL='${{ github.event.pull_request.html_url }}'
+          PR_TITLE='${{ github.event.pull_request.title }}'
+          PR_AUTHOR='${{ github.event.pull_request.user.login }}'
+          REVIEWER='${{ github.event.review.user.login }}'
+
+          REVIEWER_DISCORD_ID='${{ env[github.event.review.user.id] }}'
+          AUTHOR_DISCORD_ID='${{ env[github.event.pull_request.user.id] }}'
+
+          if [ "${{ github.event.review.state }}" = 'approved' ]; then
+            COMMENT="PR Approved 되었습니다🚀"
+            COLOR=65305
+          elif [ "${{ github.event.review.state }}" = 'changes_requested' ]; then
+            COMMENT="PR에 수정 요구사항이 있습니다👀"
+            COLOR=16736293
+          elif [ "${{ github.event.review.state }}" = 'commented' ]; then
+            COMMENT="PR에 코멘트가 등록됐습니다📝"
+            COLOR=8421504
+          else 
+            echo "Invalid review state"
+            exit 0
+          fi
+
+          JSON_FILE=$(mktemp)
+          cat > $JSON_FILE <<EOF
+          {
+            "content": "<@$AUTHOR_DISCORD_ID> $COMMENT",
+            "embeds": [
+              {
+                "author": {
+                    "name": "$PR_AUTHOR",
+                    "icon_url": "https://github.com/$PR_AUTHOR.png"
+                },
+                "title": "$PR_TITLE",
+                "url": "$PR_URL",
+                "color": $COLOR,
+                "footer": {
+                  "text": "AsyncGate"
+                },
+                "fields": [
+                  {
+                    "name": "리뷰어",
+                    "value": "$REVIEWER",
+                    "inline": true
+                  }
+                ],
+                "timestamp": "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+                }
+              ]
+            }
+          EOF
+          cat $JSON_FILE
+          curl -X POST -H 'Content-type: application/json' \
+          --data @$JSON_FILE \
+          $WEBHOOK_URL
+          rm $JSON_FILE

--- a/.github/workflows/discord-pull-request.yml
+++ b/.github/workflows/discord-pull-request.yml
@@ -1,0 +1,48 @@
+name: Discord Notification on Pull Request
+
+on:
+  pull_request:
+    types: [opened, reopened] # PR이 열렸을 때 작동합니다.
+
+jobs:
+  notify-on-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify on PR
+        run: |
+          echo "Notify on Discord"
+
+          PR_URL='${{ github.event.pull_request.html_url }}'
+          PR_TITLE='${{ github.event.pull_request.title }}'
+          PR_AUTHOR='${{ github.event.sender.login }}'
+          WEBHOOK_URL=${{ secrets.DISCORD_WEBHOOK_URL }}
+
+          JSON_FILE=$(mktemp)
+          cat > $JSON_FILE <<EOF
+          {
+            "content": "@everyone 새로운 Pull Request가 등록됐어요🔥",
+            "allowed_mentions": {
+              "parse": ["everyone"]
+            },
+            "embeds": [
+              {
+                "author": {
+                    "name": "$PR_AUTHOR",
+                    "icon_url": "https://github.com/$PR_AUTHOR.png"
+                },
+                "title": "$PR_TITLE",
+                "url": "$PR_URL",
+                "color": 6156543,
+                "footer": {
+                  "text": "AsyncGate"
+                },
+                "timestamp": "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+              }
+            ]
+          }
+          EOF
+          cat $JSON_FILE
+          curl -X POST -H 'Content-type: application/json' \
+          --data @$JSON_FILE \
+          $WEBHOOK_URL
+          rm $JSON_FILE

--- a/.github/workflows/discord-pull-request.yml
+++ b/.github/workflows/discord-pull-request.yml
@@ -20,7 +20,7 @@ jobs:
           JSON_FILE=$(mktemp)
           cat > $JSON_FILE <<EOF
           {
-            "content": "@everyone 새로운 Pull Request가 등록됐어요🔥",
+            "content": "@everyone 새로운 Pull Request가 등록됐습니다🔥",
             "allowed_mentions": {
               "parse": ["everyone"]
             },


### PR DESCRIPTION
## 이슈번호
<!-- PR 작성 시 '- Closes #<이슈번호>' 형식으로 이슈를 연결하세요. ex) '- Closes #3' -->
- Closes #13 

## 요약(개요)
- PR 생성 시 모두를 멘션해서 알림을 보냅니다.
- PR에 리뷰(코멘트, approve, RC)할 시 PR 올린 사람을 멘션해서 알림을 보냅니다.

## 작업 내용
[//]: # (업무 체크리스트를 작성해주세요.)
- [x] PR 생성 시 알림
- [x] PR 리뷰 시 알림

GitHub의 name과 디스코드의 User ID를 매핑해서 멘션 가능하게 구현했습니다. 추후 case-sensitive id를 활용하여 수정해보려 합니다.

## 집중해서 리뷰해야 하는 부분

## 기타 전달 사항 및 참고 자료(선택)
- 로컬에서 테스트를 해보지는 않았습니다. 잘 동작하는 코드를 참고했지만, 버그 발생 시 빠르게 고치겠습니다.
- GitHub Actions를 로컬에서 테스트하는 도구 `ACT`가 있는 것 같은데, 여러분들은 Actions 테스트 시 어떤 방법을 사용하시나요?