### PR TITLE
[FE] feat: 길드 카테고리 영역 및 설정 Dropdown 구현

### DIFF
--- a/src/frontend/src/api/guild.ts
+++ b/src/frontend/src/api/guild.ts
@@ -1,5 +1,5 @@
 import { endPoint } from '@/constants/endPoint';
-import { CreateGuildRequest, CreateGuildResponse, GetGuildsResponse } from '@/types/guilds';
+import { CreateGuildRequest, CreateGuildResponse, GetGuildResponse, GetGuildsResponse } from '@/types/guilds';
 import { tokenAxios } from '@/utils/axios';
 import { convertFormData } from '@/utils/convertFormData';
 
@@ -16,4 +16,9 @@ export const createGuild = async (data: CreateGuildRequest) => {
 export const getGuilds = async () => {
   const { data } = await tokenAxios.get<GetGuildsResponse>(endPoint.guilds.GET_GUILDS);
   return data.result.responses;
+};
+
+export const getGuild = async (guildId: string) => {
+  const { data } = await tokenAxios.get<GetGuildResponse>(endPoint.guilds.GET_GUILD(guildId));
+  return data.result;
 };

--- a/src/frontend/src/components/guild/GuildCategories/index.tsx
+++ b/src/frontend/src/components/guild/GuildCategories/index.tsx
@@ -1,16 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
 import { TbChevronDown, TbX } from 'react-icons/tb';
 
 import { getGuild } from '@/api/guild';
 import useDropdown from '@/hooks/useDropdown';
+import { useGuildInfoStore } from '@/stores/guildInfo';
 import { GuildResultData } from '@/types/guilds';
 
 import * as S from './styles';
-
-interface GuildCategoriesProps {
-  guildId: string;
-}
 
 interface DropdownItem {
   id: string;
@@ -18,8 +14,9 @@ interface DropdownItem {
   onClick?: () => void;
 }
 
-const GuildCategories = ({ guildId }: GuildCategoriesProps) => {
+const GuildCategories = () => {
   const { isOpened, dropdownRef, toggleDropdown } = useDropdown();
+  const { guildId } = useGuildInfoStore();
   const { data } = useQuery<GuildResultData>({ queryKey: ['serverInfo', guildId], queryFn: () => getGuild(guildId) });
 
   const dropdownItems: DropdownItem[] = [
@@ -52,19 +49,26 @@ const GuildCategories = ({ guildId }: GuildCategoriesProps) => {
 
   return (
     <S.GuildCategories>
-      <S.GuildTitle>
-        <S.GuildName>{data?.guild.name}</S.GuildName>
-        {isOpened ? <TbX size={24} onClick={toggleDropdown} /> : <TbChevronDown size={24} onClick={toggleDropdown} />}
-      </S.GuildTitle>
-
-      {isOpened && (
-        <S.DropDown ref={dropdownRef}>
-          {dropdownItems.map((item) => (
-            <S.DropDownItem key={item.id} onClick={item.onClick}>
-              <S.DropDownItemText>{item.text}</S.DropDownItemText>
-            </S.DropDownItem>
-          ))}
-        </S.DropDown>
+      {guildId && (
+        <>
+          <S.GuildTitle>
+            <S.GuildName>{data?.guild.name}</S.GuildName>
+            {isOpened ? (
+              <TbX size={24} onClick={toggleDropdown} />
+            ) : (
+              <TbChevronDown size={24} onClick={toggleDropdown} />
+            )}
+          </S.GuildTitle>
+          {isOpened && (
+            <S.DropDown ref={dropdownRef}>
+              {dropdownItems.map((item) => (
+                <S.DropDownItem key={item.id} onClick={item.onClick}>
+                  <S.DropDownItemText>{item.text}</S.DropDownItemText>
+                </S.DropDownItem>
+              ))}
+            </S.DropDown>
+          )}
+        </>
       )}
     </S.GuildCategories>
   );

--- a/src/frontend/src/components/guild/GuildCategories/index.tsx
+++ b/src/frontend/src/components/guild/GuildCategories/index.tsx
@@ -51,13 +51,9 @@ const GuildCategories = () => {
     <S.GuildCategories>
       {guildId && (
         <>
-          <S.GuildTitle>
+          <S.GuildTitle onClick={toggleDropdown}>
             <S.GuildName>{data?.guild.name}</S.GuildName>
-            {isOpened ? (
-              <TbX size={24} onClick={toggleDropdown} />
-            ) : (
-              <TbChevronDown size={24} onClick={toggleDropdown} />
-            )}
+            {isOpened ? <TbX size={24} onClick={toggleDropdown} /> : <TbChevronDown size={24} />}
           </S.GuildTitle>
           {isOpened && (
             <S.DropDown ref={dropdownRef}>

--- a/src/frontend/src/components/guild/GuildCategories/index.tsx
+++ b/src/frontend/src/components/guild/GuildCategories/index.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { TbChevronDown, TbX } from 'react-icons/tb';
 
 import { getGuild } from '@/api/guild';
+import useDropdown from '@/hooks/useDropdown';
 import { GuildResultData } from '@/types/guilds';
 
 import * as S from './styles';
@@ -18,12 +19,8 @@ interface DropdownItem {
 }
 
 const GuildCategories = ({ guildId }: GuildCategoriesProps) => {
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const { isOpened, dropdownRef, toggleDropdown } = useDropdown();
   const { data } = useQuery<GuildResultData>({ queryKey: ['serverInfo', guildId], queryFn: () => getGuild(guildId) });
-
-  const toggleDown = () => {
-    setIsDropdownOpen((prev) => !prev);
-  };
 
   const dropdownItems: DropdownItem[] = [
     {
@@ -57,11 +54,11 @@ const GuildCategories = ({ guildId }: GuildCategoriesProps) => {
     <S.GuildCategories>
       <S.GuildTitle>
         <S.GuildName>{data?.guild.name}</S.GuildName>
-        {isDropdownOpen ? <TbX size={24} onClick={toggleDown} /> : <TbChevronDown size={24} onClick={toggleDown} />}
+        {isOpened ? <TbX size={24} onClick={toggleDropdown} /> : <TbChevronDown size={24} onClick={toggleDropdown} />}
       </S.GuildTitle>
 
-      {isDropdownOpen && (
-        <S.DropDown>
+      {isOpened && (
+        <S.DropDown ref={dropdownRef}>
           {dropdownItems.map((item) => (
             <S.DropDownItem key={item.id} onClick={item.onClick}>
               <S.DropDownItemText>{item.text}</S.DropDownItemText>

--- a/src/frontend/src/components/guild/GuildCategories/index.tsx
+++ b/src/frontend/src/components/guild/GuildCategories/index.tsx
@@ -19,7 +19,7 @@ interface DropdownItem {
 
 const GuildCategories = ({ guildId }: GuildCategoriesProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const { data } = useQuery<GuildResultData>({ queryKey: ['server-info', guildId], queryFn: () => getGuild(guildId) });
+  const { data } = useQuery<GuildResultData>({ queryKey: ['serverInfo', guildId], queryFn: () => getGuild(guildId) });
 
   const toggleDown = () => {
     setIsDropdownOpen((prev) => !prev);
@@ -37,12 +37,12 @@ const GuildCategories = ({ guildId }: GuildCategoriesProps) => {
       onClick: () => console.log('초대하기 모달 열기'),
     },
     {
-      id: 'create-category',
+      id: 'createCategory',
       text: '카테고리 생성',
       onClick: () => console.log('카테고리 생성 모달 열기'),
     },
     {
-      id: 'create-channel',
+      id: 'createChannel',
       text: '채널 생성',
       onClick: () => console.log('채널 생성 모달 열기'),
     },

--- a/src/frontend/src/components/guild/GuildCategories/index.tsx
+++ b/src/frontend/src/components/guild/GuildCategories/index.tsx
@@ -11,6 +11,12 @@ interface GuildCategoriesProps {
   guildId: string;
 }
 
+interface DropdownItem {
+  id: string;
+  text: string;
+  onClick?: () => void;
+}
+
 const GuildCategories = ({ guildId }: GuildCategoriesProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const { data } = useQuery<GuildResultData>({ queryKey: ['server-info', guildId], queryFn: () => getGuild(guildId) });
@@ -18,6 +24,34 @@ const GuildCategories = ({ guildId }: GuildCategoriesProps) => {
   const toggleDown = () => {
     setIsDropdownOpen((prev) => !prev);
   };
+
+  const dropdownItems: DropdownItem[] = [
+    {
+      id: 'settings',
+      text: '서버 설정',
+      onClick: () => console.log('서버 설정 모달 열기'),
+    },
+    {
+      id: 'invite',
+      text: '초대하기',
+      onClick: () => console.log('초대하기 모달 열기'),
+    },
+    {
+      id: 'create-category',
+      text: '카테고리 생성',
+      onClick: () => console.log('카테고리 생성 모달 열기'),
+    },
+    {
+      id: 'create-channel',
+      text: '채널 생성',
+      onClick: () => console.log('채널 생성 모달 열기'),
+    },
+    {
+      id: 'leave',
+      text: '서버 나가기',
+      onClick: () => console.log('서버 나가기 모달 열기'),
+    },
+  ];
 
   return (
     <S.GuildCategories>
@@ -28,15 +62,11 @@ const GuildCategories = ({ guildId }: GuildCategoriesProps) => {
 
       {isDropdownOpen && (
         <S.DropDown>
-          <S.DropDownItem>
-            <S.DropDownItemText>서버 설정</S.DropDownItemText>
-          </S.DropDownItem>
-          <S.DropDownItem>
-            <S.DropDownItemText>초대하기</S.DropDownItemText>
-          </S.DropDownItem>
-          <S.DropDownItem>
-            <S.DropDownItemText>서버 나가기</S.DropDownItemText>
-          </S.DropDownItem>
+          {dropdownItems.map((item) => (
+            <S.DropDownItem key={item.id} onClick={item.onClick}>
+              <S.DropDownItemText>{item.text}</S.DropDownItemText>
+            </S.DropDownItem>
+          ))}
         </S.DropDown>
       )}
     </S.GuildCategories>

--- a/src/frontend/src/components/guild/GuildCategories/index.tsx
+++ b/src/frontend/src/components/guild/GuildCategories/index.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { TbChevronDown } from 'react-icons/tb';
+import { useState } from 'react';
+import { TbChevronDown, TbX } from 'react-icons/tb';
 
 import { getGuild } from '@/api/guild';
 import { GuildResultData } from '@/types/guilds';
@@ -11,14 +12,33 @@ interface GuildCategoriesProps {
 }
 
 const GuildCategories = ({ guildId }: GuildCategoriesProps) => {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const { data } = useQuery<GuildResultData>({ queryKey: ['server-info'], queryFn: () => getGuild(guildId) });
+
+  const toggleDown = () => {
+    setIsDropdownOpen((prev) => !prev);
+  };
 
   return (
     <S.GuildCategories>
       <S.GuildTitle>
         <S.GuildName>{data?.guild.name}</S.GuildName>
-        <TbChevronDown size={24} />
+        {isDropdownOpen ? <TbX size={24} onClick={toggleDown} /> : <TbChevronDown size={24} onClick={toggleDown} />}
       </S.GuildTitle>
+
+      {isDropdownOpen && (
+        <S.DropDown>
+          <S.DropDownItem>
+            <S.DropDownItemText>서버 설정</S.DropDownItemText>
+          </S.DropDownItem>
+          <S.DropDownItem>
+            <S.DropDownItemText>초대하기</S.DropDownItemText>
+          </S.DropDownItem>
+          <S.DropDownItem>
+            <S.DropDownItemText>서버 나가기</S.DropDownItemText>
+          </S.DropDownItem>
+        </S.DropDown>
+      )}
     </S.GuildCategories>
   );
 };

--- a/src/frontend/src/components/guild/GuildCategories/index.tsx
+++ b/src/frontend/src/components/guild/GuildCategories/index.tsx
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { TbChevronDown } from 'react-icons/tb';
+
+import { getGuild } from '@/api/guild';
+import { GuildResultData } from '@/types/guilds';
+
+import * as S from './styles';
+
+interface GuildCategoriesProps {
+  guildId: string;
+}
+
+const GuildCategories = ({ guildId }: GuildCategoriesProps) => {
+  const { data } = useQuery<GuildResultData>({ queryKey: ['server-info'], queryFn: () => getGuild(guildId) });
+
+  return (
+    <S.GuildCategories>
+      <S.GuildTitle>
+        <S.GuildName>{data?.guild.name}</S.GuildName>
+        <TbChevronDown size={24} />
+      </S.GuildTitle>
+    </S.GuildCategories>
+  );
+};
+
+export default GuildCategories;

--- a/src/frontend/src/components/guild/GuildCategories/index.tsx
+++ b/src/frontend/src/components/guild/GuildCategories/index.tsx
@@ -13,7 +13,7 @@ interface GuildCategoriesProps {
 
 const GuildCategories = ({ guildId }: GuildCategoriesProps) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const { data } = useQuery<GuildResultData>({ queryKey: ['server-info'], queryFn: () => getGuild(guildId) });
+  const { data } = useQuery<GuildResultData>({ queryKey: ['server-info', guildId], queryFn: () => getGuild(guildId) });
 
   const toggleDown = () => {
     setIsDropdownOpen((prev) => !prev);

--- a/src/frontend/src/components/guild/GuildCategories/index.tsx
+++ b/src/frontend/src/components/guild/GuildCategories/index.tsx
@@ -17,7 +17,7 @@ interface DropdownItem {
 const GuildCategories = () => {
   const { isOpened, dropdownRef, toggleDropdown } = useDropdown();
   const { guildId } = useGuildInfoStore();
-  const { data } = useQuery<GuildResultData>({ queryKey: ['serverInfo', guildId], queryFn: () => getGuild(guildId) });
+  const { data } = useQuery<GuildResultData>({ queryKey: ['guildInfo', guildId], queryFn: () => getGuild(guildId) });
 
   const dropdownItems: DropdownItem[] = [
     {

--- a/src/frontend/src/components/guild/GuildCategories/styles.ts
+++ b/src/frontend/src/components/guild/GuildCategories/styles.ts
@@ -9,9 +9,15 @@ export const GuildCategories = styled.div`
 `;
 
 export const GuildTitle = styled.div`
+  cursor: pointer;
+
   position: relative;
+
   display: flex;
   justify-content: space-between;
+
+  padding-bottom: 0.2rem;
+  border-bottom: 0.1rem solid ${({ theme }) => theme.colors.dark[500]};
 
   svg {
     cursor: pointer;

--- a/src/frontend/src/components/guild/GuildCategories/styles.ts
+++ b/src/frontend/src/components/guild/GuildCategories/styles.ts
@@ -16,7 +16,7 @@ export const GuildTitle = styled.div`
   display: flex;
   justify-content: space-between;
 
-  padding-bottom: 0.2rem;
+  padding-bottom: 1.6rem;
   border-bottom: 0.1rem solid ${({ theme }) => theme.colors.dark[500]};
 
   svg {

--- a/src/frontend/src/components/guild/GuildCategories/styles.ts
+++ b/src/frontend/src/components/guild/GuildCategories/styles.ts
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+import { TitleText2 } from '@/styles/Typography';
+
+export const GuildCategories = styled.div`
+  width: 24rem;
+  padding: 1.6rem 1rem;
+  background-color: ${({ theme }) => theme.colors.dark[700]};
+`;
+
+export const GuildTitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  svg {
+    cursor: pointer;
+    color: ${({ theme }) => theme.colors.dark[300]};
+  }
+`;
+
+export const GuildName = styled(TitleText2)`
+  color: ${({ theme }) => theme.colors.dark[300]};
+`;

--- a/src/frontend/src/components/guild/GuildCategories/styles.ts
+++ b/src/frontend/src/components/guild/GuildCategories/styles.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { TitleText2 } from '@/styles/Typography';
+import { TitleText2, BodyRegularText } from '@/styles/Typography';
 
 export const GuildCategories = styled.div`
   width: 24rem;
@@ -9,6 +9,7 @@ export const GuildCategories = styled.div`
 `;
 
 export const GuildTitle = styled.div`
+  position: relative;
   display: flex;
   justify-content: space-between;
 
@@ -19,5 +20,30 @@ export const GuildTitle = styled.div`
 `;
 
 export const GuildName = styled(TitleText2)`
+  color: ${({ theme }) => theme.colors.dark[300]};
+`;
+
+export const DropDown = styled.div`
+  position: absolute;
+  z-index: 10;
+  top: 6%;
+
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  width: 100%;
+  max-width: 24rem;
+  padding: 0.8rem 1rem;
+  border-radius: 0.4rem;
+
+  background-color: ${({ theme }) => theme.colors.black};
+`;
+
+export const DropDownItem = styled.div`
+  cursor: pointer;
+`;
+
+export const DropDownItemText = styled(BodyRegularText)`
   color: ${({ theme }) => theme.colors.dark[300]};
 `;

--- a/src/frontend/src/components/guild/GuildList/index.tsx
+++ b/src/frontend/src/components/guild/GuildList/index.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { getGuilds } from '@/api/guild';
+import { useGuildInfoStore } from '@/stores/guildInfo';
 import useModalStore from '@/stores/modalStore';
 import { GuildResponse } from '@/types/guilds';
 
@@ -10,6 +11,7 @@ import * as S from './styles';
 
 const GuildList = () => {
   const { openModal } = useModalStore();
+  const { setGuildId } = useGuildInfoStore();
 
   const { data } = useQuery<GuildResponse[]>({ queryKey: ['server-list'], queryFn: getGuilds });
 
@@ -23,7 +25,12 @@ const GuildList = () => {
         <S.DiscordIcon size={32} />
       </S.DMButton>
       {data?.map((guild) => (
-        <S.GuildButton key={guild.guildId} data-tooltip={guild.name} $imageUrl={guild.profileImageUrl} />
+        <S.GuildButton
+          key={guild.guildId}
+          data-tooltip={guild.name}
+          $imageUrl={guild.profileImageUrl}
+          onClick={() => setGuildId(guild.guildId)}
+        />
       ))}
       <S.AddGuildButton onClick={handleChangeModal}>
         <S.PlusIcon size={24} />

--- a/src/frontend/src/components/guild/GuildList/index.tsx
+++ b/src/frontend/src/components/guild/GuildList/index.tsx
@@ -13,7 +13,7 @@ const GuildList = () => {
   const { openModal } = useModalStore();
   const { setGuildId } = useGuildInfoStore();
 
-  const { data } = useQuery<GuildResponse[]>({ queryKey: ['server-list'], queryFn: getGuilds });
+  const { data } = useQuery<GuildResponse[]>({ queryKey: ['serverList'], queryFn: getGuilds });
 
   const handleChangeModal = () => {
     openModal('basic', <CreateGuildModalContent />);

--- a/src/frontend/src/components/guild/GuildList/index.tsx
+++ b/src/frontend/src/components/guild/GuildList/index.tsx
@@ -13,7 +13,7 @@ const GuildList = () => {
   const { openModal } = useModalStore();
   const { setGuildId } = useGuildInfoStore();
 
-  const { data } = useQuery<GuildResponse[]>({ queryKey: ['serverList'], queryFn: getGuilds });
+  const { data } = useQuery<GuildResponse[]>({ queryKey: ['guildList'], queryFn: getGuilds });
 
   const handleChangeModal = () => {
     openModal('basic', <CreateGuildModalContent />);

--- a/src/frontend/src/components/guild/GuildList/index.tsx
+++ b/src/frontend/src/components/guild/GuildList/index.tsx
@@ -21,7 +21,7 @@ const GuildList = () => {
 
   return (
     <S.GuildList>
-      <S.DMButton>
+      <S.DMButton onClick={() => setGuildId('')}>
         <S.DiscordIcon size={32} />
       </S.DMButton>
       {data?.map((guild) => (

--- a/src/frontend/src/pages/FriendsPage/components/CustomizeGuildModal/index.tsx
+++ b/src/frontend/src/pages/FriendsPage/components/CustomizeGuildModal/index.tsx
@@ -43,7 +43,7 @@ const CustomizeGuildModal = ({
 
       await createGuild(requestData);
 
-      queryClient.invalidateQueries({ queryKey: ['server-list'] });
+      queryClient.invalidateQueries({ queryKey: ['serverList'] });
 
       closeAllModal();
     } catch (error) {

--- a/src/frontend/src/pages/FriendsPage/components/CustomizeGuildModal/index.tsx
+++ b/src/frontend/src/pages/FriendsPage/components/CustomizeGuildModal/index.tsx
@@ -43,7 +43,7 @@ const CustomizeGuildModal = ({
 
       await createGuild(requestData);
 
-      queryClient.invalidateQueries({ queryKey: ['serverList'] });
+      queryClient.invalidateQueries({ queryKey: ['guildList'] });
 
       closeAllModal();
     } catch (error) {

--- a/src/frontend/src/pages/FriendsPage/index.tsx
+++ b/src/frontend/src/pages/FriendsPage/index.tsx
@@ -1,11 +1,19 @@
+import GuildCategories from '@/components/guild/GuildCategories';
+import { useGuildInfoStore } from '@/stores/guildInfo';
+
 import GuildList from '../../components/guild/GuildList';
 
 import * as S from './styles';
 
 const FriendsPage = () => {
+  const { guildId } = useGuildInfoStore();
+
   return (
     <S.FriendsPage>
-      <GuildList />
+      <S.ContentContainer>
+        <GuildList />
+        {guildId && <GuildCategories guildId={guildId} />}
+      </S.ContentContainer>
     </S.FriendsPage>
   );
 };

--- a/src/frontend/src/pages/FriendsPage/index.tsx
+++ b/src/frontend/src/pages/FriendsPage/index.tsx
@@ -1,18 +1,15 @@
 import GuildCategories from '@/components/guild/GuildCategories';
-import { useGuildInfoStore } from '@/stores/guildInfo';
 
 import GuildList from '../../components/guild/GuildList';
 
 import * as S from './styles';
 
 const FriendsPage = () => {
-  const { guildId } = useGuildInfoStore();
-
   return (
     <S.FriendsPage>
       <S.ContentContainer>
         <GuildList />
-        {guildId && <GuildCategories guildId={guildId} />}
+        <GuildCategories />
       </S.ContentContainer>
     </S.FriendsPage>
   );

--- a/src/frontend/src/pages/FriendsPage/styles.ts
+++ b/src/frontend/src/pages/FriendsPage/styles.ts
@@ -5,3 +5,10 @@ export const FriendsPage = styled.div`
   height: 100vh;
   background-color: ${({ theme }) => theme.colors.dark[500]};
 `;
+
+export const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+`;

--- a/src/frontend/src/stores/guildInfo.ts
+++ b/src/frontend/src/stores/guildInfo.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type GuildState = {
+  guildId: string;
+  setGuildId: (guildId: string) => void;
+};
+
+export const useGuildInfoStore = create<GuildState>()(
+  persist(
+    (set) => ({
+      guildId: '',
+      setGuildId: (guildId) => set({ guildId }),
+    }),
+    {
+      name: 'guild-info',
+    },
+  ),
+);

--- a/src/frontend/src/types/guilds.ts
+++ b/src/frontend/src/types/guilds.ts
@@ -32,3 +32,31 @@ export interface GuildResponse {
   name: string;
   profileImageUrl: string;
 }
+
+export interface GetGuildResponse {
+  httpStatus: number;
+  message: string;
+  time: string;
+  result: GuildResultData;
+}
+
+export interface GuildResultData {
+  guild: GuildResult;
+  categories: CategoryResult[];
+  channels: ChannelResult[];
+}
+
+interface CategoryResult {
+  categoryId: string;
+  name: string;
+  isPrivate: boolean;
+}
+
+interface ChannelResult {
+  channelId: string;
+  categoryId: string;
+  name: string;
+  topic: string;
+  channelType: string;
+  isPrivate: boolean;
+}


### PR DESCRIPTION
## 이슈번호
<!-- PR 작성 시 '- Closes #<이슈번호>' 형식으로 이슈를 연결하세요. ex) '- Closes #3' -->
- Closes #66 

## 요약(개요)
길드 선택시 카테고리가 뜨는 영역을 구현합니다
각 길드의 설정을 할 수 있는 dropdown을 구현합니다

## 작업 내용
[//]: # (업무 체크리스트를 작성해주세요.)
- [x] GuildCategories 레이아웃
- [x] 단일 길드 정보 조회 api 구현
- [x] dropdwon 구현

## 집중해서 리뷰해야 하는 부분

## 기타 전달 사항 및 참고 자료(선택)
- 기능별로 알맞는 모달을 만든 이후, GuildCategories에서 onClick시 열어주시면 될 것 같아요! 필요한 메뉴가 있다면 `dropdownItems`에서 수정 가능해요!
- 아이콘은... 잠시 미루어두었습니다 ㅎㅎ ... 😇
- `GuildCategories`에 길드 단일 정보 조회 api를 붙여놨어요! 본 컴포넌트에서 받고있는 data 값은 api 명세서 `길드 단일 조회`에서 result에 해당하는 값들이 오고있으니 참고하시면 될 것 같아요 :)


https://github.com/user-attachments/assets/98016269-a0ed-493e-9d06-d2c02e66a8b3

