### PR TITLE
[FE] feat: 유저 프로필 영역 및 탭 구현

### DIFF
--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -7,15 +7,18 @@ import { ThemeProvider } from 'styled-components';
 import router from './router';
 import GlobalStyle from './styles/GlobalStyle';
 import theme from './styles/theme';
+import retryQuery from './utils/retryQuery';
 
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       throwOnError: true,
       refetchOnWindowFocus: false,
+      retry: retryQuery,
     },
     mutations: {
       throwOnError: true,
+      retry: retryQuery,
     },
   },
 });
@@ -25,7 +28,7 @@ createRoot(document.getElementById('root')!).render(
     <ThemeProvider theme={theme}>
       <GlobalStyle />
       <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router}/>
+        <RouterProvider router={router} />
       </QueryClientProvider>
     </ThemeProvider>
   </StrictMode>,

--- a/src/frontend/src/pages/FriendsPage/components/UserProfile/index.tsx
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfile/index.tsx
@@ -1,0 +1,59 @@
+import { IoMicSharp, IoMicOffSharp } from 'react-icons/io5';
+import { MdHeadset, MdHeadsetOff } from 'react-icons/md';
+import { RiSettings5Fill } from 'react-icons/ri';
+
+import useDropdown from '@/hooks/useDropdown';
+
+import UserProfileTab from '../UserProfileTab';
+
+import * as S from './styles';
+
+interface UserProfileProps {
+  userImageUrl: string;
+  userName: string;
+  isOnline: boolean;
+  isMicOn: boolean;
+  isHeadsetOn: boolean;
+  handleMicToggle: (value: boolean) => void;
+  handleHeadsetToggle: (value: boolean) => void;
+}
+
+const UserProfile = ({
+  userImageUrl,
+  userName,
+  isOnline,
+  isMicOn,
+  isHeadsetOn,
+  handleMicToggle,
+  handleHeadsetToggle,
+}: UserProfileProps) => {
+  const { isOpened, dropdownRef, toggleDropdown } = useDropdown();
+
+  return (
+    <S.UserProfileContainer ref={dropdownRef}>
+      <S.UserInfoContainer onClick={toggleDropdown}>
+        <S.UserImage $userImageUrl={userImageUrl}>
+          <S.UserStatusMark $isOnline={isOnline} />
+        </S.UserImage>
+        <S.UserInfo>
+          <S.UserName>{userName}</S.UserName>
+          <S.UserStatus>{isOnline ? '온라인' : '오프라인'}</S.UserStatus>
+        </S.UserInfo>
+      </S.UserInfoContainer>
+      <S.ControlButtonContainer>
+        <S.ControlButton onClick={() => handleMicToggle(!isMicOn)}>
+          {isMicOn ? <IoMicSharp color="lightgray" size={20} /> : <IoMicOffSharp color="red" size={20} />}
+        </S.ControlButton>
+        <S.ControlButton onClick={() => handleHeadsetToggle(!isHeadsetOn)}>
+          {isHeadsetOn ? <MdHeadset color="lightgray" size={20} /> : <MdHeadsetOff color="red" size={20} />}
+        </S.ControlButton>
+        <S.ControlButton>
+          <RiSettings5Fill color="lightgray" size={20} />
+        </S.ControlButton>
+      </S.ControlButtonContainer>
+      {isOpened && <UserProfileTab />}
+    </S.UserProfileContainer>
+  );
+};
+
+export default UserProfile;

--- a/src/frontend/src/pages/FriendsPage/components/UserProfile/index.tsx
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfile/index.tsx
@@ -14,8 +14,8 @@ interface UserProfileProps {
   isOnline: boolean;
   isMicOn: boolean;
   isHeadsetOn: boolean;
-  handleMicToggle: (value: boolean) => void;
-  handleHeadsetToggle: (value: boolean) => void;
+  handleMicToggle: () => void;
+  handleHeadsetToggle: () => void;
 }
 
 const UserProfile = ({
@@ -41,10 +41,10 @@ const UserProfile = ({
         </S.UserInfo>
       </S.UserInfoContainer>
       <S.ControlButtonContainer>
-        <S.ControlButton onClick={() => handleMicToggle(!isMicOn)}>
+        <S.ControlButton onClick={handleMicToggle}>
           {isMicOn ? <IoMicSharp color="lightgray" size={20} /> : <IoMicOffSharp color="red" size={20} />}
         </S.ControlButton>
-        <S.ControlButton onClick={() => handleHeadsetToggle(!isHeadsetOn)}>
+        <S.ControlButton onClick={handleHeadsetToggle}>
           {isHeadsetOn ? <MdHeadset color="lightgray" size={20} /> : <MdHeadsetOff color="red" size={20} />}
         </S.ControlButton>
         <S.ControlButton>

--- a/src/frontend/src/pages/FriendsPage/components/UserProfile/styles.ts
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfile/styles.ts
@@ -1,0 +1,92 @@
+import styled from 'styled-components';
+
+import { ChipText } from '@/styles/Typography';
+
+export const UserProfileContainer = styled.div`
+  position: relative;
+
+  display: flex;
+  align-items: center;
+
+  width: 100%;
+  height: 5.2rem;
+  padding: 0 1rem;
+
+  background-color: ${({ theme }) => theme.colors.dark[800]};
+`;
+
+export const UserInfoContainer = styled.div`
+  cursor: pointer;
+
+  display: flex;
+  align-items: center;
+
+  width: 12rem;
+  border-radius: 0.4rem;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.dark[500]};
+  }
+`;
+
+export const UserImage = styled.div<{ $userImageUrl: string }>`
+  position: relative;
+
+  min-width: 3.2rem;
+  height: 3.2rem;
+  border-radius: 50%;
+
+  background-color: ${({ theme }) => theme.colors.white};
+  background-image: url(${(props) => props.$userImageUrl});
+`;
+
+export const UserStatusMark = styled.div<{ $isOnline: boolean }>`
+  position: absolute;
+  right: 0;
+  bottom: 0;
+
+  width: 1rem;
+  height: 1rem;
+  border: 0.1rem solid ${({ theme }) => theme.colors.dark[400]};
+  border-radius: 50%;
+
+  background-color: ${({ $isOnline }) => ($isOnline ? 'green' : 'black')};
+`;
+
+export const UserInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 0.4rem 0 0.4rem 0.8rem;
+`;
+
+export const UserName = styled(ChipText)`
+  width: 100%;
+  line-height: 1.6rem;
+  color: ${({ theme }) => theme.colors.white};
+`;
+
+export const UserStatus = styled(ChipText)`
+  width: 100%;
+  line-height: 1.6rem;
+  color: ${({ theme }) => theme.colors.dark[300]};
+`;
+
+export const ControlButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+export const ControlButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 3.2rem;
+  height: 3.2rem;
+  border-radius: 0.4rem;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.dark[500]};
+  }
+`;

--- a/src/frontend/src/pages/FriendsPage/components/UserProfileTab/hooks/useUserProfileTabElements.ts
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfileTab/hooks/useUserProfileTabElements.ts
@@ -1,0 +1,37 @@
+import { useNavigate } from 'react-router-dom';
+
+interface MenuItem {
+  elementId: string;
+  content: string;
+  handleClick: () => void;
+}
+
+const useUserProfileTabElements = () => {
+  const navigate = useNavigate();
+  const handleModifyProfile = () => {
+    // 추후 정보 수정 모달 구현
+    console.log('사용자 정보 수정 메뉴 클릭');
+  };
+
+  const handleLogout = () => {
+    localStorage.removeItem('access_token');
+    navigate('/login', { replace: true });
+  };
+
+  const userProfileTabElements: MenuItem[] = [
+    {
+      elementId: 'modifyUserProfile',
+      content: '사용자 정보 수정',
+      handleClick: handleModifyProfile,
+    },
+    {
+      elementId: 'logout',
+      content: '로그아웃',
+      handleClick: handleLogout,
+    },
+  ];
+
+  return { userProfileTabElements };
+};
+
+export default useUserProfileTabElements;

--- a/src/frontend/src/pages/FriendsPage/components/UserProfileTab/index.tsx
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfileTab/index.tsx
@@ -1,0 +1,17 @@
+import useUserProfileTabElements from './hooks/useUserProfileTabElements';
+import * as S from './styles';
+const UserProfileTab = () => {
+  const { userProfileTabElements } = useUserProfileTabElements();
+
+  return (
+    <S.DropdownContainer>
+      {userProfileTabElements.map((element) => (
+        <S.DropdownMenu key={element.elementId} onClick={element.handleClick}>
+          <S.MenuContent>{element.content}</S.MenuContent>
+        </S.DropdownMenu>
+      ))}
+    </S.DropdownContainer>
+  );
+};
+
+export default UserProfileTab;

--- a/src/frontend/src/pages/FriendsPage/components/UserProfileTab/styles.ts
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfileTab/styles.ts
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+
+import { ChipText } from '@/styles/Typography';
+
+export const DropdownContainer = styled.ul`
+  position: absolute;
+  bottom: 6rem;
+  left: 0;
+
+  width: 120%;
+  padding: 1.6rem;
+  border-radius: 0.4rem;
+
+  background-color: ${({ theme }) => theme.colors.dark[800]};
+`;
+
+export const DropdownMenu = styled.li`
+  cursor: pointer;
+
+  display: flex;
+  align-items: center;
+
+  width: 100%;
+  padding: 1.2rem 1rem;
+  border-radius: 0.4rem;
+
+  background-color: ${({ theme }) => theme.colors.dark[600]};
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.dark[500]};
+  }
+`;
+
+export const MenuContent = styled(ChipText)`
+  color: ${({ theme }) => theme.colors.white};
+`;

--- a/src/frontend/src/utils/retryQuery.ts
+++ b/src/frontend/src/utils/retryQuery.ts
@@ -1,0 +1,11 @@
+const retryQuery = (failureCount: number, error: Error): boolean => {
+  const extractedCode = error.message.match(/\b5\d{2}\b/); // 500번대 에러 검사
+  if (!extractedCode) return false; // 400번대 에러의 경우 재시도하지 않음
+
+  const statusCode = Number(extractedCode[0]);
+
+  if (statusCode >= 500 && statusCode < 600) return failureCount < 1; // 500번대 에러는 한 번 재시도
+  return false;
+};
+
+export default retryQuery;


### PR DESCRIPTION
## 이슈번호
<!-- PR 작성 시 '- Closes #<이슈번호>' 형식으로 이슈를 연결하세요. ex) '- Closes #3' -->
- Closes #68 

## 요약(개요)
- 길드 페이지에서 카테고리 목록 하단에 보이는 유저 프로필 영역을 구현했습니다.
![image](https://github.com/user-attachments/assets/082de117-f331-4371-8875-06d29831378b)
- 프로필 정보와 온라인 여부, 마이크/헤드셋/설정 버튼을 추가했습니다.

- 유저 프로필 부분을 클릭하는 경우, 메뉴 탭이 열립니다.
![image](https://github.com/user-attachments/assets/7f45d4cc-c1f4-4eab-9473-737de0187e8d)
- 유저 정보 수정 및 로그아웃이 가능합니다. 정보 수정은 추후 개발할 예정이고, 로그아웃은 localStorage의 access_token을 지우고 로그인 페이지로 이동시킵니다.

## 작업 내용
[//]: # (업무 체크리스트를 작성해주세요.)
- [x] 유저 프로필 영역 구현
- [x] 유저 프로필 탭 구현

## 집중해서 리뷰해야 하는 부분

## 기타 전달 사항 및 참고 자료(선택)
- 프로필 영역은 카테고리 영역의 하단에 padding 없이 붙어있어요. 이 부분은 추후 카테고리 리스트 PR이 머지된 뒤에 수정하겠습니다. 아직은 해당 컴포넌트를 배치하지 않았습니다.