### PR TITLE
[FE] feat: 친구 관련 및 DM api 연동

### DIFF
--- a/src/frontend/src/api/directMessages.ts
+++ b/src/frontend/src/api/directMessages.ts
@@ -1,0 +1,17 @@
+import { endPoint } from '@/constants/endPoint';
+import { GetDirectMessagesResponse, PostDirectMessageRequest } from '@/types/directMessages';
+import { tokenAxios } from '@/utils/axios';
+
+export const getDirects = async () => {
+  const { data } = await tokenAxios.get<GetDirectMessagesResponse>(endPoint.directMessages.GET_DIRECTS);
+  return data.result.directResponses;
+};
+
+interface PostDirectParams {
+  bodyRequest: PostDirectMessageRequest;
+}
+
+export const postDirect = async ({ bodyRequest }: PostDirectParams) => {
+  const { data } = await tokenAxios.post(endPoint.directMessages.POST_DIRECT, bodyRequest);
+  return data.result;
+};

--- a/src/frontend/src/api/friends.ts
+++ b/src/frontend/src/api/friends.ts
@@ -3,9 +3,12 @@ import { endPoint } from '@/constants/endPoint';
 import {
   DeleteFriendResponse,
   GetFriendsListResponse,
-  GetFriendsResponse,
+  GetFriendInfoResponse,
   GetReceivedRequestsResponse,
   GetSentRequestsResponse,
+  PostAcceptResponse,
+  PostRejectResponse,
+  PostRequestResponse,
 } from '@/types/friends';
 import { tokenAxios } from '@/utils/axios';
 
@@ -23,23 +26,23 @@ interface GetFriendsParams {
 }
 
 export const GetFriends = async ({ email }: GetFriendsParams) => {
-  const { data } = await tokenAxios.get<GetFriendsResponse>(endPoint.friends.GET_FRIENDS, { params: { email } });
+  const { data } = await tokenAxios.get<GetFriendInfoResponse>(endPoint.friends.GET_FRIENDS, { params: { email } });
   return data;
 };
 
 export const GetSentRequest = async () => {
   const { data } = await tokenAxios.get<GetSentRequestsResponse>(endPoint.friends.GET_SENT_REQUESTS);
-  return data;
+  return data.result.friends;
 };
 
 export const GetReceivedRequest = async () => {
   const { data } = await tokenAxios.get<GetReceivedRequestsResponse>(endPoint.friends.GET_RECEIVED_REQUESTS);
-  return data;
+  return data.result.friends;
 };
 
 export const GetFriendsList = async () => {
   const { data } = await tokenAxios.get<GetFriendsListResponse>(endPoint.friends.GET_FRIENDS_LIST);
-  return data;
+  return data.result.friends;
 };
 
 interface PostFriendRequestParams {
@@ -47,8 +50,8 @@ interface PostFriendRequestParams {
 }
 
 export const PostFriendRequest = async ({ toUserId }: PostFriendRequestParams) => {
-  const { data } = await tokenAxios.post<PostFriendRequestParams>(endPoint.friends.POST_REQUEST(toUserId));
-  return data;
+  const { data } = await tokenAxios.post<PostRequestResponse>(endPoint.friends.POST_REQUEST(toUserId));
+  return data.result;
 };
 
 interface PostRejectRequestParams {
@@ -56,8 +59,8 @@ interface PostRejectRequestParams {
 }
 
 export const PostRejectRequest = async ({ friendId }: PostRejectRequestParams) => {
-  const { data } = await tokenAxios.post<PostRejectRequestParams>(endPoint.friends.POST_REJECT_REQUEST(friendId));
-  return data;
+  const { data } = await tokenAxios.post<PostRejectResponse>(endPoint.friends.POST_REJECT_REQUEST(friendId));
+  return data.result;
 };
 
 interface PostAcceptRequestParams {
@@ -65,6 +68,6 @@ interface PostAcceptRequestParams {
 }
 
 export const PostAcceptRequest = async ({ friendId }: PostAcceptRequestParams) => {
-  const { data } = await tokenAxios.post<PostAcceptRequestParams>(endPoint.friends.POST_ACCEPT_REQUEST(friendId));
-  return data;
+  const { data } = await tokenAxios.post<PostAcceptResponse>(endPoint.friends.POST_ACCEPT_REQUEST(friendId));
+  return data.result;
 };

--- a/src/frontend/src/api/friends.ts
+++ b/src/frontend/src/api/friends.ts
@@ -20,13 +20,13 @@ export const deleteFriend = async ({ friendId }: DeleteFriendParams) => {
   return data;
 };
 
-interface GetFriendsParams {
+interface GetFriendInfoParams {
   email: string;
 }
 
-export const getFriends = async ({ email }: GetFriendsParams) => {
+export const getFriendInfo = async ({ email }: GetFriendInfoParams) => {
   const { data } = await tokenAxios.get<GetFriendInfoResponse>(endPoint.friends.GET_FRIENDS, { params: { email } });
-  return data;
+  return data.result;
 };
 
 export const getSentRequest = async () => {

--- a/src/frontend/src/api/friends.ts
+++ b/src/frontend/src/api/friends.ts
@@ -16,7 +16,7 @@ interface DeleteFriendParams {
   friendId: string;
 }
 
-export const DeleteFriend = async ({ friendId }: DeleteFriendParams) => {
+export const deleteFriend = async ({ friendId }: DeleteFriendParams) => {
   const { data } = await tokenAxios.delete<DeleteFriendResponse>(endPoint.friends.DELETE_FRIEND(friendId));
   return data;
 };
@@ -25,22 +25,22 @@ interface GetFriendsParams {
   email: string;
 }
 
-export const GetFriends = async ({ email }: GetFriendsParams) => {
+export const getFriends = async ({ email }: GetFriendsParams) => {
   const { data } = await tokenAxios.get<GetFriendInfoResponse>(endPoint.friends.GET_FRIENDS, { params: { email } });
   return data;
 };
 
-export const GetSentRequest = async () => {
+export const getSentRequest = async () => {
   const { data } = await tokenAxios.get<GetSentRequestsResponse>(endPoint.friends.GET_SENT_REQUESTS);
   return data.result.friends;
 };
 
-export const GetReceivedRequest = async () => {
+export const getReceivedRequest = async () => {
   const { data } = await tokenAxios.get<GetReceivedRequestsResponse>(endPoint.friends.GET_RECEIVED_REQUESTS);
   return data.result.friends;
 };
 
-export const GetFriendsList = async () => {
+export const getFriendsList = async () => {
   const { data } = await tokenAxios.get<GetFriendsListResponse>(endPoint.friends.GET_FRIENDS_LIST);
   return data.result.friends;
 };
@@ -49,7 +49,7 @@ interface PostFriendRequestParams {
   toUserId: string;
 }
 
-export const PostFriendRequest = async ({ toUserId }: PostFriendRequestParams) => {
+export const postFriendRequest = async ({ toUserId }: PostFriendRequestParams) => {
   const { data } = await tokenAxios.post<PostRequestResponse>(endPoint.friends.POST_REQUEST(toUserId));
   return data.result;
 };
@@ -58,7 +58,7 @@ interface PostRejectRequestParams {
   friendId: string;
 }
 
-export const PostRejectRequest = async ({ friendId }: PostRejectRequestParams) => {
+export const postRejectRequest = async ({ friendId }: PostRejectRequestParams) => {
   const { data } = await tokenAxios.post<PostRejectResponse>(endPoint.friends.POST_REJECT_REQUEST(friendId));
   return data.result;
 };
@@ -67,7 +67,7 @@ interface PostAcceptRequestParams {
   friendId: string;
 }
 
-export const PostAcceptRequest = async ({ friendId }: PostAcceptRequestParams) => {
+export const postAcceptRequest = async ({ friendId }: PostAcceptRequestParams) => {
   const { data } = await tokenAxios.post<PostAcceptResponse>(endPoint.friends.POST_ACCEPT_REQUEST(friendId));
   return data.result;
 };

--- a/src/frontend/src/api/friends.ts
+++ b/src/frontend/src/api/friends.ts
@@ -1,0 +1,70 @@
+import { FriendCount } from '@/components/friend/FriendsList/styles';
+import { endPoint } from '@/constants/endPoint';
+import {
+  DeleteFriendResponse,
+  GetFriendsListResponse,
+  GetFriendsResponse,
+  GetReceivedRequestsResponse,
+  GetSentRequestsResponse,
+} from '@/types/friends';
+import { tokenAxios } from '@/utils/axios';
+
+interface DeleteFriendParams {
+  friendId: string;
+}
+
+export const DeleteFriend = async ({ friendId }: DeleteFriendParams) => {
+  const { data } = await tokenAxios.delete<DeleteFriendResponse>(endPoint.friends.DELETE_FRIEND(friendId));
+  return data;
+};
+
+interface GetFriendsParams {
+  email: string;
+}
+
+export const GetFriends = async ({ email }: GetFriendsParams) => {
+  const { data } = await tokenAxios.get<GetFriendsResponse>(endPoint.friends.GET_FRIENDS, { params: { email } });
+  return data;
+};
+
+export const GetSentRequest = async () => {
+  const { data } = await tokenAxios.get<GetSentRequestsResponse>(endPoint.friends.GET_SENT_REQUESTS);
+  return data;
+};
+
+export const GetReceivedRequest = async () => {
+  const { data } = await tokenAxios.get<GetReceivedRequestsResponse>(endPoint.friends.GET_RECEIVED_REQUESTS);
+  return data;
+};
+
+export const GetFriendsList = async () => {
+  const { data } = await tokenAxios.get<GetFriendsListResponse>(endPoint.friends.GET_FRIENDS_LIST);
+  return data;
+};
+
+interface PostFriendRequestParams {
+  toUserId: string;
+}
+
+export const PostFriendRequest = async ({ toUserId }: PostFriendRequestParams) => {
+  const { data } = await tokenAxios.post<PostFriendRequestParams>(endPoint.friends.POST_REQUEST(toUserId));
+  return data;
+};
+
+interface PostRejectRequestParams {
+  friendId: string;
+}
+
+export const PostRejectRequest = async ({ friendId }: PostRejectRequestParams) => {
+  const { data } = await tokenAxios.post<PostRejectRequestParams>(endPoint.friends.POST_REJECT_REQUEST(friendId));
+  return data;
+};
+
+interface PostAcceptRequestParams {
+  friendId: string;
+}
+
+export const PostAcceptRequest = async ({ friendId }: PostAcceptRequestParams) => {
+  const { data } = await tokenAxios.post<PostAcceptRequestParams>(endPoint.friends.POST_ACCEPT_REQUEST(friendId));
+  return data;
+};

--- a/src/frontend/src/api/friends.ts
+++ b/src/frontend/src/api/friends.ts
@@ -1,4 +1,3 @@
-import { FriendCount } from '@/components/friend/FriendsList/styles';
 import { endPoint } from '@/constants/endPoint';
 import {
   DeleteFriendResponse,

--- a/src/frontend/src/api/users.ts
+++ b/src/frontend/src/api/users.ts
@@ -1,5 +1,6 @@
 import { endPoint } from '@/constants/endPoint';
 import {
+  GetUserInfoResponse,
   PatchUserInfoRequest,
   PatchUserInfoResponse,
   PostAuthCodeRequest,
@@ -38,12 +39,17 @@ export const postEmailDuplicate = async ({ email }: PostEmailDuplicateParams) =>
   return data;
 };
 
+export const getUserInfo = async () => {
+  const { data } = await tokenAxios.get<GetUserInfoResponse>(endPoint.users.GET_USER_INFO);
+  return data;
+};
+
 interface PatchUserInfoParams {
   userId: string;
   bodyRequest: PatchUserInfoRequest;
 }
 
-export const PatchUserInfo = async ({ userId, bodyRequest }: PatchUserInfoParams) => {
+export const patchUserInfo = async ({ userId, bodyRequest }: PatchUserInfoParams) => {
   const { data } = await publicAxios.patch<PatchUserInfoResponse>(endPoint.users.PATCH_USER_INFO, bodyRequest, {
     params: userId,
   });

--- a/src/frontend/src/api/users.ts
+++ b/src/frontend/src/api/users.ts
@@ -13,6 +13,15 @@ import {
 } from '@/types/users';
 import { publicAxios, tokenAxios } from '@/utils/axios';
 
+interface DeleteAccountParams {
+  userId: string;
+}
+
+export const deleteAccount = async ({ userId }: DeleteAccountParams) => {
+  const { data } = await tokenAxios.delete(endPoint.users.DELETE_USER, { params: userId });
+  return data;
+};
+
 export const postLogin = async (requestBody: PostLoginRequest) => {
   const { data } = await publicAxios.post<PostLoginResponse>(endPoint.users.POST_SIGN_IN, requestBody);
   return data;

--- a/src/frontend/src/components/common/AuthCheckbox/index.tsx
+++ b/src/frontend/src/components/common/AuthCheckbox/index.tsx
@@ -3,7 +3,7 @@ import CheckedIcon from '@/assets/checked.svg';
 import * as S from './styles';
 
 interface AuthCheckboxProps {
-  id: string;
+  id?: string;
   isChecked: boolean;
   handleChange?: () => void;
   label?: string;

--- a/src/frontend/src/components/common/Modal/index.tsx
+++ b/src/frontend/src/components/common/Modal/index.tsx
@@ -15,7 +15,7 @@ const Modal = ({ children, name }: ModalProps) => {
 
   return (
     <>
-      <S.Overlay onClick={() => closeModal(name, 'close-modal')} />
+      <S.Overlay onClick={() => closeModal(name, 'closeModal')} />
       <S.ModalContainer>
         <S.CloseButton>
           <S.CloseIcon size={28} onClick={() => closeAllModal()} />

--- a/src/frontend/src/components/common/Modal/styles.ts
+++ b/src/frontend/src/components/common/Modal/styles.ts
@@ -51,8 +51,7 @@ export const FooterWrapper = styled.div`
   align-items: center;
   justify-content: center;
 
-  margin-top: 1.6rem;
-  padding: 2.4rem 2.4rem 0;
+  padding: 0 2.4rem 2.4rem;
 `;
 
 export const CloseButton = styled.div`

--- a/src/frontend/src/components/friend/AddFriendForm/index.tsx
+++ b/src/frontend/src/components/friend/AddFriendForm/index.tsx
@@ -1,10 +1,6 @@
 import { useState } from 'react';
 
-import { getFriends, getFriendsList, getReceivedRequest, getSentRequest, postFriendRequest } from '@/api/friends';
-
-import useGetFriendsList from '../FriendsList/hooks/useGetFriendsList';
-import useGetReceivedRequests from '../PendingFriendsList/hooks/useGetReceivedRequests';
-import useGetSentRequests from '../PendingFriendsList/hooks/useGetSentRequests';
+import { getFriendInfo, getFriendsList, getReceivedRequest, getSentRequest, postFriendRequest } from '@/api/friends';
 
 import * as S from './styles';
 
@@ -50,7 +46,7 @@ const AddFriendForm = () => {
         return null;
       }
 
-      const response = await getFriends({ email: inputData });
+      const response = await getFriendInfo({ email: inputData });
       return response;
     } catch (error) {
       console.log('회원 검색 실패', error);
@@ -64,7 +60,7 @@ const AddFriendForm = () => {
       const friendInfo = await getFriendInfoByEmail();
       if (!friendInfo) return;
 
-      await postFriendRequest({ toUserId: friendInfo.userId }); // friendInfo에 userId가 있어야 함
+      await postFriendRequest({ toUserId: friendInfo.userId });
 
       setResultMessage({ type: 'success', content: '친구 요청을 보냈어요!' });
     } catch (error) {

--- a/src/frontend/src/components/friend/AddFriendForm/index.tsx
+++ b/src/frontend/src/components/friend/AddFriendForm/index.tsx
@@ -1,5 +1,11 @@
 import { useState } from 'react';
 
+import { getFriends, postFriendRequest } from '@/api/friends';
+
+import useGetFriendsList from '../FriendsList/hooks/useGetFriendsList';
+import useGetReceivedRequests from '../PendingFriendsList/hooks/useGetReceivedRequests';
+import useGetSentRequests from '../PendingFriendsList/hooks/useGetSentRequests';
+
 import * as S from './styles';
 
 export type ResultMessageType = 'success' | 'fail';
@@ -10,17 +16,58 @@ interface ResultMessage {
 }
 
 const AddFriendForm = () => {
-  // TODO: 친구 검색 및 요청 보내기 로직 연동
-  // TODO: 요청 보내기 결과에 따라 resultMessage를 설정하고 표시
   const [inputData, setInputData] = useState('');
   const [resultMessage, setResultMessage] = useState<ResultMessage | null>(null);
+
+  const { friends } = useGetFriendsList();
+  const { sentRequests } = useGetSentRequests();
+  const { receivedRequests } = useGetReceivedRequests();
 
   const handleInputChange = (value: string) => {
     setInputData(value);
   };
 
-  const handleSendRequestButtonClick = () => {
-    console.log('친구 요청');
+  const getFriendInfoByEmail = async () => {
+    // 1. 이미 친구로 등록된 사용자인지 확인
+    if (friends && friends.some((friend) => friend.email === inputData)) {
+      setResultMessage({ type: 'fail', content: '이미 친구로 등록된 사용자예요.' });
+      return null;
+    }
+
+    // 2. 이미 친구 요청을 보낸 사용자인지 확인
+    if (sentRequests && sentRequests.some((request) => request.email === inputData)) {
+      setResultMessage({ type: 'fail', content: '이미 친구 요청을 보냈어요. 상대방의 응답을 기다려주세요.' });
+      return null;
+    }
+
+    // 3. 상대가 이미 친구 요청을 보냈는지 확인
+    if (receivedRequests && receivedRequests.some((request) => request.email === inputData)) {
+      setResultMessage({ type: 'fail', content: '상대방이 이미 친구 요청을 보냈어요. 친구 요청을 확인해주세요.' });
+      return null;
+    }
+
+    try {
+      const response = await getFriends({ email: inputData });
+      return response;
+    } catch (error) {
+      console.log('회원 검색 실패', error);
+      setResultMessage({ type: 'fail', content: '회원 검색에 실패했어요. 다시 시도해주세요.' });
+      return null;
+    }
+  };
+
+  const handleSendRequestButtonClick = async () => {
+    try {
+      const friendInfo = await getFriendInfoByEmail();
+      if (!friendInfo) return;
+
+      await postFriendRequest({ toUserId: friendInfo.userId }); // friendInfo에 userId가 있어야 함
+
+      setResultMessage({ type: 'success', content: '친구 요청을 보냈어요!' });
+    } catch (error) {
+      console.log('친구 요청 실패', error);
+      setResultMessage({ type: 'fail', content: '친구 요청을 보내는 데 실패했어요. 다시 시도해주세요.' });
+    }
   };
 
   return (

--- a/src/frontend/src/components/friend/AddFriendForm/index.tsx
+++ b/src/frontend/src/components/friend/AddFriendForm/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { getFriendInfo, getFriendsList, getReceivedRequest, getSentRequest, postFriendRequest } from '@/api/friends';
+import useGetUserInfo from '@/pages/FriendsPage/components/UserProfile/hooks/useGetUserInfo';
 
 import * as S from './styles';
 
@@ -12,6 +13,7 @@ interface ResultMessage {
 }
 
 const AddFriendForm = () => {
+  const { userInfo } = useGetUserInfo();
   const [inputData, setInputData] = useState('');
   const [resultMessage, setResultMessage] = useState<ResultMessage | null>(null);
 
@@ -28,19 +30,25 @@ const AddFriendForm = () => {
         getReceivedRequest(),
       ]);
 
-      // 1. 이미 친구로 등록된 사용자인지 확인
+      // 1. 자신을 친구로 추가하려 하는지 확인
+      if (userInfo?.email === inputData) {
+        setResultMessage({ type: 'fail', content: '본인은 추가할 수 없어요.' });
+        return null;
+      }
+
+      // 2. 이미 친구로 등록된 사용자인지 확인
       if (friends && friends.some((friend) => friend.email === inputData)) {
         setResultMessage({ type: 'fail', content: '이미 친구로 등록된 사용자예요.' });
         return null;
       }
 
-      // 2. 이미 친구 요청을 보낸 사용자인지 확인
+      // 3. 이미 친구 요청을 보낸 사용자인지 확인
       if (sentRequests && sentRequests.some((request) => request.email === inputData)) {
         setResultMessage({ type: 'fail', content: '이미 친구 요청을 보냈어요. 상대방의 응답을 기다려주세요.' });
         return null;
       }
 
-      // 3. 상대가 이미 친구 요청을 보냈는지 확인
+      // 4. 상대가 이미 친구 요청을 보냈는지 확인
       if (receivedRequests && receivedRequests.some((request) => request.email === inputData)) {
         setResultMessage({ type: 'fail', content: '상대방이 이미 친구 요청을 보냈어요. 친구 요청을 확인해주세요.' });
         return null;

--- a/src/frontend/src/components/friend/AddFriendForm/styles.ts
+++ b/src/frontend/src/components/friend/AddFriendForm/styles.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-import { BodyRegularText, ChipText, TitleText2 } from '@/styles/Typography';
+import { BodyRegularText, TitleText2 } from '@/styles/Typography';
 
 import { ResultMessageType } from '.';
 

--- a/src/frontend/src/components/friend/CreateDirectMessageModal/hooks/usePostDirect.ts
+++ b/src/frontend/src/components/friend/CreateDirectMessageModal/hooks/usePostDirect.ts
@@ -16,7 +16,11 @@ const usePostDirect = () => {
     },
   });
 
-  return { createDirectMessageMutation };
+  const createDirectMessage = (memberIds: string[]) => {
+    createDirectMessageMutation.mutate({ bodyRequest: { memberIds } });
+  };
+
+  return { createDirectMessage, createDirectMessageMutation };
 };
 
 export default usePostDirect;

--- a/src/frontend/src/components/friend/CreateDirectMessageModal/hooks/usePostDirect.ts
+++ b/src/frontend/src/components/friend/CreateDirectMessageModal/hooks/usePostDirect.ts
@@ -14,13 +14,16 @@ const usePostDirect = () => {
       queryClient.invalidateQueries({ queryKey: ['directMessagesList'] });
       closeAllModal();
     },
+    onError: (error) => {
+      console.error('DM 생성 실패', error);
+    },
   });
 
   const createDirectMessage = (memberIds: string[]) => {
     createDirectMessageMutation.mutate({ bodyRequest: { memberIds } });
   };
 
-  return { createDirectMessage, createDirectMessageMutation };
+  return { createDirectMessage, isPending: createDirectMessageMutation.isPending };
 };
 
 export default usePostDirect;

--- a/src/frontend/src/components/friend/CreateDirectMessageModal/hooks/usePostDirect.ts
+++ b/src/frontend/src/components/friend/CreateDirectMessageModal/hooks/usePostDirect.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { postDirect } from '@/api/directMessages';
+import useModalStore from '@/stores/modalStore';
+
+const usePostDirect = () => {
+  const queryClient = useQueryClient();
+  const { closeAllModal } = useModalStore();
+
+  const createDirectMessageMutation = useMutation({
+    mutationFn: postDirect,
+    mutationKey: ['createDirectMessage'],
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['directMessagesList'] });
+      closeAllModal();
+    },
+  });
+
+  return { createDirectMessageMutation };
+};
+
+export default usePostDirect;

--- a/src/frontend/src/components/friend/CreateDirectMessageModal/index.tsx
+++ b/src/frontend/src/components/friend/CreateDirectMessageModal/index.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+
+import AuthCheckbox from '@/components/common/AuthCheckbox';
+import Modal from '@/components/common/Modal';
+
+import useGetFriendsList from '../FriendsList/hooks/useGetFriendsList';
+
+import usePostDirect from './hooks/usePostDirect';
+import * as S from './styles';
+
+const MAX_DIRECT_MESSAGE_FRIENDS = 9;
+
+const CreateDirectMessageModal = () => {
+  const [selectedFriends, setSelectedFriends] = useState<string[]>([]);
+  const { createDirectMessageMutation } = usePostDirect();
+  const { friends } = useGetFriendsList();
+  if (!friends) return null;
+
+  const handleCheckboxClick = (userId: string) => {
+    // 이미 선택된 친구를 누르면 선택 해제 가능
+    if (selectedFriends.length === MAX_DIRECT_MESSAGE_FRIENDS) {
+      if (!selectedFriends.includes(userId)) return;
+    }
+
+    setSelectedFriends((prev) => (prev.includes(userId) ? prev.filter((id) => id !== userId) : [...prev, userId]));
+  };
+
+  const handleCreateDirectMessage = async () => {
+    try {
+      createDirectMessageMutation.mutate({ bodyRequest: { memberIds: selectedFriends } });
+    } catch (error) {
+      console.log('DM 생성 실패', error);
+    }
+  };
+
+  const isButtonDisabled = !selectedFriends.length || createDirectMessageMutation.isPending;
+
+  return (
+    <Modal name="withFooter">
+      <Modal.Header>
+        <S.ModalTitle>친구 선택하기</S.ModalTitle>
+        <S.SelectedFriendsCount>
+          친구를 {MAX_DIRECT_MESSAGE_FRIENDS - selectedFriends.length}명 더 선택할 수 있어요.
+        </S.SelectedFriendsCount>
+      </Modal.Header>
+      <Modal.Content>
+        <S.FriendList>
+          {friends.map((friend) => (
+            <S.FriendItem key={friend.userId} onClick={() => handleCheckboxClick(friend.userId)}>
+              <S.FriendProfileImage $imageUrl={friend.profileImageUrl}>
+                <S.FriendStatusMark $isOnline={true} />
+              </S.FriendProfileImage>
+              <S.FriendInfo>
+                <S.FriendNickname>{friend.nickname}</S.FriendNickname>
+              </S.FriendInfo>
+              <AuthCheckbox isChecked={selectedFriends.includes(friend.userId)} />
+            </S.FriendItem>
+          ))}
+        </S.FriendList>
+      </Modal.Content>
+      <Modal.Footer>
+        <S.CreateButton disabled={isButtonDisabled} $isDisabled={isButtonDisabled} onClick={handleCreateDirectMessage}>
+          {createDirectMessageMutation.isPending ? '요청 중...' : 'DM 생성'}
+        </S.CreateButton>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default CreateDirectMessageModal;

--- a/src/frontend/src/components/friend/CreateDirectMessageModal/index.tsx
+++ b/src/frontend/src/components/friend/CreateDirectMessageModal/index.tsx
@@ -52,6 +52,7 @@ const CreateDirectMessageModal = () => {
               </S.FriendProfileImage>
               <S.FriendInfo>
                 <S.FriendNickname>{friend.nickname}</S.FriendNickname>
+                <S.FriendName>{friend.name}</S.FriendName>
               </S.FriendInfo>
               <AuthCheckbox isChecked={selectedFriends.includes(friend.userId)} />
             </S.FriendItem>

--- a/src/frontend/src/components/friend/CreateDirectMessageModal/index.tsx
+++ b/src/frontend/src/components/friend/CreateDirectMessageModal/index.tsx
@@ -12,7 +12,7 @@ const MAX_DIRECT_MESSAGE_FRIENDS = 9;
 
 const CreateDirectMessageModal = () => {
   const [selectedFriends, setSelectedFriends] = useState<string[]>([]);
-  const { createDirectMessageMutation } = usePostDirect();
+  const { createDirectMessage, isPending } = usePostDirect();
   const { friends } = useGetFriendsList();
   if (!friends) return null;
 
@@ -26,14 +26,10 @@ const CreateDirectMessageModal = () => {
   };
 
   const handleCreateDirectMessage = async () => {
-    try {
-      createDirectMessageMutation.mutate({ bodyRequest: { memberIds: selectedFriends } });
-    } catch (error) {
-      console.log('DM 생성 실패', error);
-    }
+    createDirectMessage(selectedFriends);
   };
 
-  const isButtonDisabled = !selectedFriends.length || createDirectMessageMutation.isPending;
+  const isButtonDisabled = !selectedFriends.length || isPending;
 
   return (
     <Modal name="withFooter">
@@ -61,7 +57,7 @@ const CreateDirectMessageModal = () => {
       </Modal.Content>
       <Modal.Footer>
         <S.CreateButton disabled={isButtonDisabled} $isDisabled={isButtonDisabled} onClick={handleCreateDirectMessage}>
-          {createDirectMessageMutation.isPending ? '요청 중...' : 'DM 생성'}
+          {isPending ? '요청 중...' : 'DM 생성'}
         </S.CreateButton>
       </Modal.Footer>
     </Modal>

--- a/src/frontend/src/components/friend/CreateDirectMessageModal/styles.ts
+++ b/src/frontend/src/components/friend/CreateDirectMessageModal/styles.ts
@@ -72,16 +72,20 @@ export const FriendStatusMark = styled.div<{ $isOnline: boolean }>`
 
 export const FriendInfo = styled.div`
   display: flex;
-  flex-direction: column;
   flex-grow: 1;
+  gap: 0.4rem;
+  align-items: center;
+
   min-width: 0;
 `;
 
 export const FriendNickname = styled(BodyRegularText)`
-  overflow: hidden;
   color: ${({ theme }) => theme.colors.white};
-  text-overflow: ellipsis;
-  white-space: nowrap;
+`;
+
+export const FriendName = styled(ChipText)`
+  line-height: 1.4rem;
+  color: ${({ theme }) => theme.colors.dark[300]};
 `;
 
 export const CreateButton = styled.button<{ $isDisabled: boolean }>`

--- a/src/frontend/src/components/friend/CreateDirectMessageModal/styles.ts
+++ b/src/frontend/src/components/friend/CreateDirectMessageModal/styles.ts
@@ -67,7 +67,7 @@ export const FriendStatusMark = styled.div<{ $isOnline: boolean }>`
   border: 0.1rem solid ${({ theme }) => theme.colors.dark[400]};
   border-radius: 50%;
 
-  background-color: ${({ $isOnline }) => ($isOnline ? 'green' : 'black')};
+  background-color: ${({ theme, $isOnline }) => ($isOnline ? theme.colors.online : theme.colors.black)};
 `;
 
 export const FriendInfo = styled.div`

--- a/src/frontend/src/components/friend/CreateDirectMessageModal/styles.ts
+++ b/src/frontend/src/components/friend/CreateDirectMessageModal/styles.ts
@@ -1,0 +1,98 @@
+import styled from 'styled-components';
+
+import { BodyMediumText, BodyRegularText, ChipText } from '@/styles/Typography';
+
+export const ModalTitle = styled(BodyMediumText)`
+  font-size: 2rem;
+`;
+
+export const SelectedFriendsCount = styled(ChipText)`
+  color: ${({ theme }) => theme.colors.dark[300]};
+`;
+
+export const FriendList = styled.ul`
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+
+  height: fit-content;
+  max-height: 27rem;
+
+  &::-webkit-scrollbar-thumb {
+    border: 0.1rem solid ${({ theme }) => theme.colors.dark[600]};
+    border-radius: 0.3rem;
+    background: ${({ theme }) => theme.colors.dark[800]};
+  }
+
+  &::-webkit-scrollbar {
+    width: 0.6rem;
+  }
+`;
+
+export const FriendItem = styled.li`
+  cursor: pointer;
+
+  display: flex;
+  align-items: center;
+
+  min-height: 4rem;
+  padding: 0 0.8rem;
+  border-radius: 0.4rem;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.dark[600]};
+  }
+`;
+
+export const FriendProfileImage = styled.div<{ $imageUrl: string }>`
+  position: relative;
+
+  width: 3.2rem;
+  height: 3.2rem;
+  margin-right: 1.2rem;
+  border-radius: 50%;
+
+  background-color: ${({ theme }) => theme.colors.white};
+  background-image: url(${(props) => props.$imageUrl});
+`;
+
+export const FriendStatusMark = styled.div<{ $isOnline: boolean }>`
+  position: absolute;
+  right: 0;
+  bottom: 0;
+
+  width: 1rem;
+  height: 1rem;
+  border: 0.1rem solid ${({ theme }) => theme.colors.dark[400]};
+  border-radius: 50%;
+
+  background-color: ${({ $isOnline }) => ($isOnline ? 'green' : 'black')};
+`;
+
+export const FriendInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  min-width: 0;
+`;
+
+export const FriendNickname = styled(BodyRegularText)`
+  overflow: hidden;
+  color: ${({ theme }) => theme.colors.white};
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const CreateButton = styled.button<{ $isDisabled: boolean }>`
+  cursor: ${({ $isDisabled }) => ($isDisabled ? 'not-allowed' : 'pointer')};
+
+  width: 100%;
+  height: 3.8rem;
+  border-radius: 0.4rem;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  opacity: ${({ $isDisabled }) => ($isDisabled ? 0.5 : 1)};
+  background-color: ${({ theme }) => theme.colors.blue};
+`;

--- a/src/frontend/src/components/friend/DeleteFriendConfirmModal/hooks/useDeleteFriend.ts
+++ b/src/frontend/src/components/friend/DeleteFriendConfirmModal/hooks/useDeleteFriend.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deleteFriend } from '@/api/friends';
+
+const useDeleteFriend = () => {
+  const queryClient = useQueryClient();
+
+  const deleteFriendMutation = useMutation({
+    mutationFn: (friendId: string) => deleteFriend({ friendId }),
+    mutationKey: ['deleteFriend'],
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['friendsList'] });
+    },
+    onError: (error) => {
+      console.error('친구 삭제 실패', error);
+    },
+  });
+
+  const deleteFriendMutate = (friendId: string) => {
+    deleteFriendMutation.mutate(friendId);
+  };
+
+  return { deleteFriend: deleteFriendMutate, isPending: deleteFriendMutation.isPending };
+};
+
+export default useDeleteFriend;

--- a/src/frontend/src/components/friend/DeleteFriendConfirmModal/index.tsx
+++ b/src/frontend/src/components/friend/DeleteFriendConfirmModal/index.tsx
@@ -1,9 +1,7 @@
-import { useQueryClient } from '@tanstack/react-query';
-
-import { deleteFriend } from '@/api/friends';
 import Modal from '@/components/common/Modal';
 import useModalStore from '@/stores/modalStore';
 
+import useDeleteFriend from './hooks/useDeleteFriend';
 import * as S from './styles';
 
 interface DeleteFriendConfirmModalProps {
@@ -12,17 +10,8 @@ interface DeleteFriendConfirmModalProps {
 }
 
 const DeleteFriendConfirmModal = ({ friendId, friendNickname }: DeleteFriendConfirmModalProps) => {
-  const queryClient = useQueryClient();
   const { closeAllModal } = useModalStore();
-
-  const handleDeleteFriend = async () => {
-    try {
-      await deleteFriend({ friendId });
-      queryClient.invalidateQueries({ queryKey: ['friendsList'] });
-    } catch (error) {
-      console.error('친구 삭제 실패', error);
-    }
-  };
+  const { deleteFriend, isPending } = useDeleteFriend();
 
   return (
     <Modal name="withFooter">
@@ -33,7 +22,9 @@ const DeleteFriendConfirmModal = ({ friendId, friendNickname }: DeleteFriendConf
       </Modal.Content>
       <S.ModalButtonContainer>
         <S.CancelButton onClick={closeAllModal}>취소</S.CancelButton>
-        <S.DeleteButton onClick={handleDeleteFriend}>친구 삭제하기</S.DeleteButton>
+        <S.DeleteButton disabled={isPending} $isPending={isPending} onClick={() => deleteFriend(friendId)}>
+          친구 삭제하기
+        </S.DeleteButton>
       </S.ModalButtonContainer>
     </Modal>
   );

--- a/src/frontend/src/components/friend/DeleteFriendConfirmModal/index.tsx
+++ b/src/frontend/src/components/friend/DeleteFriendConfirmModal/index.tsx
@@ -1,0 +1,42 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import { deleteFriend } from '@/api/friends';
+import Modal from '@/components/common/Modal';
+import useModalStore from '@/stores/modalStore';
+
+import * as S from './styles';
+
+interface DeleteFriendConfirmModalProps {
+  friendId: string;
+  friendNickname: string;
+}
+
+const DeleteFriendConfirmModal = ({ friendId, friendNickname }: DeleteFriendConfirmModalProps) => {
+  const queryClient = useQueryClient();
+  const { closeAllModal } = useModalStore();
+
+  const handleDeleteFriend = async () => {
+    try {
+      await deleteFriend({ friendId });
+      queryClient.invalidateQueries({ queryKey: ['friendsList'] });
+    } catch (error) {
+      console.error('친구 삭제 실패', error);
+    }
+  };
+
+  return (
+    <Modal name="withFooter">
+      <Modal.Content>
+        <S.ConfirmText>
+          정말 <strong>{friendNickname}</strong> 님을 친구에서 삭제하시겠어요?
+        </S.ConfirmText>
+      </Modal.Content>
+      <S.ModalButtonContainer>
+        <S.CancelButton onClick={closeAllModal}>취소</S.CancelButton>
+        <S.DeleteButton onClick={handleDeleteFriend}>친구 삭제하기</S.DeleteButton>
+      </S.ModalButtonContainer>
+    </Modal>
+  );
+};
+
+export default DeleteFriendConfirmModal;

--- a/src/frontend/src/components/friend/DeleteFriendConfirmModal/styles.ts
+++ b/src/frontend/src/components/friend/DeleteFriendConfirmModal/styles.ts
@@ -28,7 +28,9 @@ export const CancelButton = styled.button`
   }
 `;
 
-export const DeleteButton = styled.button`
+export const DeleteButton = styled.button<{ $isPending: boolean }>`
+  cursor: ${({ $isPending }) => $isPending && 'not-allowed'};
+
   height: 3.8rem;
   padding: 0.2rem 1.6rem;
   border-radius: 0.4rem;

--- a/src/frontend/src/components/friend/DeleteFriendConfirmModal/styles.ts
+++ b/src/frontend/src/components/friend/DeleteFriendConfirmModal/styles.ts
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+import { BodyMediumText } from '@/styles/Typography';
+
+export const ConfirmText = styled(BodyMediumText)`
+  color: ${({ theme }) => theme.colors.white};
+`;
+
+export const ModalButtonContainer = styled.div`
+  display: flex;
+  gap: 1.6rem;
+  align-items: center;
+  justify-content: flex-end;
+
+  height: 7rem;
+  padding: 1.6rem;
+
+  background-color: ${({ theme }) => theme.colors.dark[600]};
+`;
+
+export const CancelButton = styled.button`
+  height: 3.8rem;
+  padding: 0.2rem 1.6rem;
+  color: ${({ theme }) => theme.colors.white};
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+export const DeleteButton = styled.button`
+  height: 3.8rem;
+  padding: 0.2rem 1.6rem;
+  border-radius: 0.4rem;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  background-color: ${({ theme }) => theme.colors.red};
+
+  &:hover {
+    opacity: 0.8;
+  }
+`;

--- a/src/frontend/src/components/friend/DirectMessageCategory/index.tsx
+++ b/src/frontend/src/components/friend/DirectMessageCategory/index.tsx
@@ -1,12 +1,30 @@
+import { MdPerson } from 'react-icons/md';
+
+import { useChannelInfoStore } from '@/stores/channelInfo';
+import { BodyMediumText } from '@/styles/Typography';
+
 import * as S from './styles';
 
 const DirectMessageCategory = () => {
+  const { selectedDMChannel, setSelectedDMChannel } = useChannelInfoStore();
+
+  const handleFriendsTabClick = () => {
+    setSelectedDMChannel(null);
+  };
+
   return (
     <>
       <S.FriendTitle>
         <S.TitleName>다이렉트 메시지</S.TitleName>
       </S.FriendTitle>
-      {/* TODO: 친구 채팅방 목록 */}
+      <S.TabList>
+        <S.TabItem $isSelected={!selectedDMChannel} onClick={handleFriendsTabClick}>
+          <S.TabIcon>
+            <MdPerson size={28} />
+          </S.TabIcon>
+          <BodyMediumText>친구</BodyMediumText>
+        </S.TabItem>
+      </S.TabList>
     </>
   );
 };

--- a/src/frontend/src/components/friend/DirectMessageCategory/index.tsx
+++ b/src/frontend/src/components/friend/DirectMessageCategory/index.tsx
@@ -3,6 +3,8 @@ import { MdPerson } from 'react-icons/md';
 import { useChannelInfoStore } from '@/stores/channelInfo';
 import { BodyMediumText } from '@/styles/Typography';
 
+import DirectMessagesList from '../DirectMessagesList';
+
 import * as S from './styles';
 
 const DirectMessageCategory = () => {
@@ -25,6 +27,7 @@ const DirectMessageCategory = () => {
           <BodyMediumText>친구</BodyMediumText>
         </S.TabItem>
       </S.TabList>
+      <DirectMessagesList />
     </>
   );
 };

--- a/src/frontend/src/components/friend/DirectMessageCategory/styles.ts
+++ b/src/frontend/src/components/friend/DirectMessageCategory/styles.ts
@@ -20,7 +20,7 @@ export const TitleName = styled(TitleText2)`
 export const TabList = styled.ul`
   display: flex;
   gap: 0.1rem;
-  margin: 0.8rem;
+  padding: 0.8rem 0.8rem 0;
   list-style: none;
 `;
 

--- a/src/frontend/src/components/friend/DirectMessageCategory/styles.ts
+++ b/src/frontend/src/components/friend/DirectMessageCategory/styles.ts
@@ -16,3 +16,40 @@ export const FriendTitle = styled.div`
 export const TitleName = styled(TitleText2)`
   color: ${({ theme }) => theme.colors.dark[300]};
 `;
+
+export const TabList = styled.ul`
+  display: flex;
+  gap: 0.1rem;
+  margin: 0.8rem;
+  list-style: none;
+`;
+
+export const TabItem = styled.li<{ $isSelected: boolean }>`
+  cursor: pointer;
+
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+
+  height: 4.4rem;
+  padding: 0 0.8rem;
+  border-radius: 0.4rem;
+
+  background-color: ${({ theme, $isSelected }) => ($isSelected ? theme.colors.dark[500] : '')};
+
+  & > * {
+    color: ${({ theme, $isSelected }) => ($isSelected ? theme.colors.white : theme.colors.dark[300])};
+  }
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.dark[500]};
+
+    & > * {
+      color: ${({ theme }) => theme.colors.white};
+    }
+  }
+`;
+
+export const TabIcon = styled.div`
+  margin-right: 1.2rem;
+`;

--- a/src/frontend/src/components/friend/DirectMessagesList/index.tsx
+++ b/src/frontend/src/components/friend/DirectMessagesList/index.tsx
@@ -3,22 +3,30 @@ import { TbPlus } from 'react-icons/tb';
 
 import { getDirects } from '@/api/directMessages';
 import { useChannelInfoStore } from '@/stores/channelInfo';
+import useModalStore from '@/stores/modalStore';
 import { useUserInfoStore } from '@/stores/userInfo';
 import { ChipText } from '@/styles/Typography';
+
+import CreateDirectMessageModal from '../CreateDirectMessageModal';
 
 import * as S from './styles';
 
 const DirectMessagesList = () => {
+  const { openModal } = useModalStore();
   const { userInfo } = useUserInfoStore();
   const { selectedDMChannel, setSelectedDMChannel } = useChannelInfoStore();
   const { data: directMessages } = useQuery({ queryKey: ['directMessagesList'], queryFn: getDirects });
   if (!directMessages) return null;
 
+  const handleCreateDirectMessageButtonClick = () => {
+    openModal('withFooter', <CreateDirectMessageModal />);
+  };
+
   return (
     <S.DirectMessagesListContainer>
       <S.CategoryName>
         <ChipText>다이렉트 메시지</ChipText>
-        <TbPlus size={18} />
+        <TbPlus size={18} onClick={handleCreateDirectMessageButtonClick} />
       </S.CategoryName>
       <S.DirectMessagesList>
         {directMessages.map(({ directId, members }) => {
@@ -33,12 +41,16 @@ const DirectMessagesList = () => {
               $isSelected={selectedDMChannel?.id === directId}
               onClick={() => setSelectedDMChannel({ id: directId, name: directMessageName, type: 'TEXT' })}
             >
-              <S.DirectMessageImage $userImageUrl={members.responses[0].profileImageUrl}>
-                {members.responses.length === 1 && <S.UserStatusMark $isOnline={true} />}
+              <S.DirectMessageImage
+                $userImageUrl={
+                  members.responses.filter((member) => member.userId !== userInfo?.userId)[0].profileImageUrl
+                }
+              >
+                {members.responses.length === 2 && <S.UserStatusMark $isOnline={true} />}
               </S.DirectMessageImage>
               <S.DirectMessageInfo>
                 <S.DirectMessageName>{directMessageName}</S.DirectMessageName>
-                {members.responses.length > 1 && <ChipText>멤버 {members.responses.length}명</ChipText>}
+                {members.responses.length > 2 && <ChipText>멤버 {members.responses.length}명</ChipText>}
               </S.DirectMessageInfo>
             </S.DirectMessageItem>
           );

--- a/src/frontend/src/components/friend/DirectMessagesList/index.tsx
+++ b/src/frontend/src/components/friend/DirectMessagesList/index.tsx
@@ -30,10 +30,8 @@ const DirectMessagesList = () => {
       </S.CategoryName>
       <S.DirectMessagesList>
         {directMessages.map(({ directId, members }) => {
-          const directMessageName = members.responses
-            .filter((member) => member.userId !== userInfo?.userId)
-            .map((member) => member.nickname)
-            .join(', ');
+          const otherMemberList = members.responses.filter((member) => member.userId !== userInfo?.userId);
+          const directMessageName = otherMemberList.map((member) => member.nickname).join(', ');
 
           return (
             <S.DirectMessageItem
@@ -41,11 +39,7 @@ const DirectMessagesList = () => {
               $isSelected={selectedDMChannel?.id === directId}
               onClick={() => setSelectedDMChannel({ id: directId, name: directMessageName, type: 'TEXT' })}
             >
-              <S.DirectMessageImage
-                $userImageUrl={
-                  members.responses.filter((member) => member.userId !== userInfo?.userId)[0].profileImageUrl
-                }
-              >
+              <S.DirectMessageImage $userImageUrl={otherMemberList[0].profileImageUrl}>
                 {members.responses.length === 2 && <S.UserStatusMark $isOnline={true} />}
               </S.DirectMessageImage>
               <S.DirectMessageInfo>

--- a/src/frontend/src/components/friend/DirectMessagesList/index.tsx
+++ b/src/frontend/src/components/friend/DirectMessagesList/index.tsx
@@ -21,28 +21,24 @@ const DirectMessagesList = () => {
         <TbPlus size={18} />
       </S.CategoryName>
       <S.DirectMessagesList>
-        {directMessages.map((directMessage) => {
-          const directMessageName = directMessage.members.responses
+        {directMessages.map(({ directId, members }) => {
+          const directMessageName = members.responses
             .filter((member) => member.userId !== userInfo?.userId)
             .map((member) => member.nickname)
             .join(', ');
 
           return (
             <S.DirectMessageItem
-              key={directMessage.directId}
-              $isSelected={selectedDMChannel?.id === directMessage.directId}
-              onClick={() =>
-                setSelectedDMChannel({ id: directMessage.directId, name: directMessageName, type: 'TEXT' })
-              }
+              key={directId}
+              $isSelected={selectedDMChannel?.id === directId}
+              onClick={() => setSelectedDMChannel({ id: directId, name: directMessageName, type: 'TEXT' })}
             >
-              <S.DirectMessageImage $userImageUrl={directMessage.members.responses[0].profileImageUrl}>
-                {directMessage.members.responses.length === 1 && <S.UserStatusMark $isOnline={true} />}
+              <S.DirectMessageImage $userImageUrl={members.responses[0].profileImageUrl}>
+                {members.responses.length === 1 && <S.UserStatusMark $isOnline={true} />}
               </S.DirectMessageImage>
               <S.DirectMessageInfo>
                 <S.DirectMessageName>{directMessageName}</S.DirectMessageName>
-                {directMessage.members.responses.length > 1 && (
-                  <ChipText>멤버 {directMessage.members.responses.length}명</ChipText>
-                )}
+                {members.responses.length > 1 && <ChipText>멤버 {members.responses.length}명</ChipText>}
               </S.DirectMessageInfo>
             </S.DirectMessageItem>
           );

--- a/src/frontend/src/components/friend/DirectMessagesList/index.tsx
+++ b/src/frontend/src/components/friend/DirectMessagesList/index.tsx
@@ -1,0 +1,55 @@
+import { useQuery } from '@tanstack/react-query';
+import { TbPlus } from 'react-icons/tb';
+
+import { getDirects } from '@/api/directMessages';
+import { useChannelInfoStore } from '@/stores/channelInfo';
+import { useUserInfoStore } from '@/stores/userInfo';
+import { ChipText } from '@/styles/Typography';
+
+import * as S from './styles';
+
+const DirectMessagesList = () => {
+  const { userInfo } = useUserInfoStore();
+  const { selectedDMChannel, setSelectedDMChannel } = useChannelInfoStore();
+  const { data: directMessages } = useQuery({ queryKey: ['directMessagesList'], queryFn: getDirects });
+  if (!directMessages) return null;
+
+  return (
+    <S.DirectMessagesListContainer>
+      <S.CategoryName>
+        <ChipText>다이렉트 메시지</ChipText>
+        <TbPlus size={18} />
+      </S.CategoryName>
+      <S.DirectMessagesList>
+        {directMessages.map((directMessage) => {
+          const directMessageName = directMessage.members.responses
+            .filter((member) => member.userId !== userInfo?.userId)
+            .map((member) => member.nickname)
+            .join(', ');
+
+          return (
+            <S.DirectMessageItem
+              key={directMessage.directId}
+              $isSelected={selectedDMChannel?.id === directMessage.directId}
+              onClick={() =>
+                setSelectedDMChannel({ id: directMessage.directId, name: directMessageName, type: 'TEXT' })
+              }
+            >
+              <S.DirectMessageImage $userImageUrl={directMessage.members.responses[0].profileImageUrl}>
+                {directMessage.members.responses.length === 1 && <S.UserStatusMark $isOnline={true} />}
+              </S.DirectMessageImage>
+              <S.DirectMessageInfo>
+                <S.DirectMessageName>{directMessageName}</S.DirectMessageName>
+                {directMessage.members.responses.length > 1 && (
+                  <ChipText>멤버 {directMessage.members.responses.length}명</ChipText>
+                )}
+              </S.DirectMessageInfo>
+            </S.DirectMessageItem>
+          );
+        })}
+      </S.DirectMessagesList>
+    </S.DirectMessagesListContainer>
+  );
+};
+
+export default DirectMessagesList;

--- a/src/frontend/src/components/friend/DirectMessagesList/styles.ts
+++ b/src/frontend/src/components/friend/DirectMessagesList/styles.ts
@@ -83,7 +83,7 @@ export const UserStatusMark = styled.div<{ $isOnline: boolean }>`
   border: 0.1rem solid ${({ theme }) => theme.colors.dark[400]};
   border-radius: 50%;
 
-  background-color: ${({ $isOnline }) => ($isOnline ? 'green' : 'black')};
+  background-color: ${({ theme, $isOnline }) => ($isOnline ? theme.colors.online : theme.colors.black)};
 `;
 
 export const DirectMessageInfo = styled.div`

--- a/src/frontend/src/components/friend/DirectMessagesList/styles.ts
+++ b/src/frontend/src/components/friend/DirectMessagesList/styles.ts
@@ -1,0 +1,104 @@
+import styled from 'styled-components';
+
+import { BodyMediumText } from '@/styles/Typography';
+
+export const DirectMessagesListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  color: ${({ theme }) => theme.colors.dark[300]};
+`;
+
+export const CategoryName = styled.div`
+  cursor: pointer;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  width: 100%;
+  padding: 1.8rem 1.6rem 0.4rem;
+
+  svg {
+    color: ${({ theme }) => theme.colors.dark[300]};
+  }
+
+  &:hover {
+    * {
+      color: ${({ theme }) => theme.colors.white};
+    }
+  }
+`;
+
+export const DirectMessagesList = styled.ul`
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+
+  width: 100%;
+  margin-top: 0.6rem;
+  padding: 0 0.8rem;
+`;
+
+export const DirectMessageItem = styled.li<{ $isSelected: boolean }>`
+  cursor: pointer;
+
+  display: flex;
+  align-items: center;
+
+  width: 100%;
+  height: 4.4rem;
+  padding: 0 0.8rem;
+  border-radius: 0.4rem;
+
+  color: ${({ theme, $isSelected }) => ($isSelected ? theme.colors.white : theme.colors.dark[300])};
+
+  background-color: ${({ theme, $isSelected }) => $isSelected && theme.colors.dark[500]};
+
+  &:hover {
+    color: ${({ theme }) => theme.colors.white};
+  }
+`;
+
+export const DirectMessageImage = styled.div<{ $userImageUrl: string }>`
+  position: relative;
+
+  min-width: 3.2rem;
+  height: 3.2rem;
+  margin-right: 1.2rem;
+  border-radius: 50%;
+
+  background-color: ${({ theme }) => theme.colors.white};
+  background-image: url(${(props) => props.$userImageUrl});
+  background-repeat: no-repeat;
+  background-size: cover;
+`;
+
+export const UserStatusMark = styled.div<{ $isOnline: boolean }>`
+  position: absolute;
+  right: 0;
+  bottom: 0;
+
+  width: 1rem;
+  height: 1rem;
+  border: 0.1rem solid ${({ theme }) => theme.colors.dark[400]};
+  border-radius: 50%;
+
+  background-color: ${({ $isOnline }) => ($isOnline ? 'green' : 'black')};
+`;
+
+export const DirectMessageInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  min-width: 0;
+`;
+
+export const DirectMessageName = styled(BodyMediumText)`
+  overflow: hidden;
+  display: block;
+
+  width: 100%;
+
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;

--- a/src/frontend/src/components/friend/FriendsList/hooks/useGetFriendsList.ts
+++ b/src/frontend/src/components/friend/FriendsList/hooks/useGetFriendsList.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getFriendsList } from '@/api/friends';
+
+const useGetFriendsList = () => {
+  const result = useQuery({ queryKey: ['friendsList'], queryFn: getFriendsList, staleTime: 10 * 60 * 1000 });
+
+  return {
+    friends: result.data,
+    ...result,
+  };
+};
+
+export default useGetFriendsList;

--- a/src/frontend/src/components/friend/FriendsList/index.tsx
+++ b/src/frontend/src/components/friend/FriendsList/index.tsx
@@ -1,13 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { GetFriendsList } from '@/api/friends';
+import { getFriendsList } from '@/api/friends';
 
 import * as S from './styles';
 
 const FriendsList = () => {
   // TODO: 상태 동적으로 변경하기
   // TODO: 내 요청을 상대방이 수락할 경우 invalidate
-  const { data: friends } = useQuery({ queryKey: ['friendsList'], queryFn: GetFriendsList, staleTime: 10 * 60 * 1000 });
+  const { data: friends } = useQuery({ queryKey: ['friendsList'], queryFn: getFriendsList, staleTime: 10 * 60 * 1000 });
   if (!friends) return null;
 
   return (

--- a/src/frontend/src/components/friend/FriendsList/index.tsx
+++ b/src/frontend/src/components/friend/FriendsList/index.tsx
@@ -1,29 +1,29 @@
-import { useQuery } from '@tanstack/react-query';
-
-import { getFriendsList } from '@/api/friends';
-
+import useGetFriendsList from './hooks/useGetFriendsList';
 import * as S from './styles';
 
 const FriendsList = () => {
   // TODO: 상태 동적으로 변경하기
   // TODO: 내 요청을 상대방이 수락할 경우 invalidate
-  const { data: friends } = useQuery({ queryKey: ['friendsList'], queryFn: getFriendsList, staleTime: 10 * 60 * 1000 });
-  if (!friends) return null;
+  const { friends } = useGetFriendsList();
 
   return (
     <S.FriendsList>
-      <S.FriendCount>모든 친구 - {friends.length}명</S.FriendCount>
-      {friends.map((friend) => (
-        <S.FriendItem key={friend.userId}>
-          <S.FriendProfileImage $imageUrl={friend.profileImageUrl}>
-            <S.FriendStatusMark $isOnline={true} />
-          </S.FriendProfileImage>
-          <S.FriendInfo>
-            <S.FriendName>{friend.name}</S.FriendName>
-            <S.FriendStatus>온라인</S.FriendStatus>
-          </S.FriendInfo>
-        </S.FriendItem>
-      ))}
+      {friends && (
+        <>
+          <S.FriendCount>모든 친구 - {friends.length}명</S.FriendCount>
+          {friends.map((friend) => (
+            <S.FriendItem key={friend.userId}>
+              <S.FriendProfileImage $imageUrl={friend.profileImageUrl}>
+                <S.FriendStatusMark $isOnline={true} />
+              </S.FriendProfileImage>
+              <S.FriendInfo>
+                <S.FriendName>{friend.name}</S.FriendName>
+                <S.FriendStatus>온라인</S.FriendStatus>
+              </S.FriendInfo>
+            </S.FriendItem>
+          ))}
+        </>
+      )}
     </S.FriendsList>
   );
 };

--- a/src/frontend/src/components/friend/FriendsList/index.tsx
+++ b/src/frontend/src/components/friend/FriendsList/index.tsx
@@ -1,3 +1,9 @@
+import { TiDelete } from 'react-icons/ti';
+
+import useModalStore from '@/stores/modalStore';
+
+import DeleteFriendConfirmModal from '../DeleteFriendConfirmModal';
+
 import useGetFriendsList from './hooks/useGetFriendsList';
 import * as S from './styles';
 
@@ -5,6 +11,11 @@ const FriendsList = () => {
   // TODO: 상태 동적으로 변경하기
   // TODO: 내 요청을 상대방이 수락할 경우 invalidate
   const { friends } = useGetFriendsList();
+  const { openModal } = useModalStore();
+
+  const handleDeleteFriendButtonClick = async (friendId: string, friendNickname: string) => {
+    openModal('withFooter', <DeleteFriendConfirmModal friendId={friendId} friendNickname={friendNickname} />);
+  };
 
   return (
     <S.FriendsList>
@@ -20,6 +31,11 @@ const FriendsList = () => {
                 <S.FriendNickname>{friend.nickname}</S.FriendNickname>
                 <S.FriendStatus>온라인</S.FriendStatus>
               </S.FriendInfo>
+              <S.IconContainer>
+                <S.IconWrapper onClick={() => handleDeleteFriendButtonClick(friend.userId, friend.nickname)}>
+                  <TiDelete size={28} />
+                </S.IconWrapper>
+              </S.IconContainer>
             </S.FriendItem>
           ))}
         </>

--- a/src/frontend/src/components/friend/FriendsList/index.tsx
+++ b/src/frontend/src/components/friend/FriendsList/index.tsx
@@ -1,41 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { GetFriendsList } from '@/api/friends';
+
 import * as S from './styles';
 
-// TODO: API 문서에 맞게 수정 및 types 폴더로 이동
-export interface Friend {
-  name: string;
-  profileImageUrl: string;
-  isOnline: boolean;
-}
-
-// TODO: useQuery로 친구 리스트 요청
-const friends: Friend[] = [
-  {
-    name: '친구1',
-    profileImageUrl: '',
-    isOnline: true,
-  },
-  {
-    name: '친구2',
-    profileImageUrl: '',
-    isOnline: true,
-  },
-  {
-    name: '친구3',
-    profileImageUrl: '',
-    isOnline: false,
-  },
-];
-
 const FriendsList = () => {
+  // TODO: 상태 동적으로 변경하기
+  // TODO: 내 요청을 상대방이 수락할 경우 invalidate
+  const { data: friends } = useQuery({ queryKey: ['friendsList'], queryFn: GetFriendsList, staleTime: 10 * 60 * 1000 });
+  if (!friends) return null;
+
   return (
     <S.FriendsList>
       <S.FriendCount>모든 친구 - {friends.length}명</S.FriendCount>
-      {friends.map((friend, index) => (
-        <S.FriendItem key={`${friend.name}_${index}`}>
+      {friends.map((friend) => (
+        <S.FriendItem key={friend.userId}>
           <S.FriendProfileImage $imageUrl={friend.profileImageUrl}>
-            <S.FriendStatusMark $isOnline={friend.isOnline} />
+            <S.FriendStatusMark $isOnline={true} />
           </S.FriendProfileImage>
-          <S.FriendName>{friend.name}</S.FriendName>
+          <S.FriendInfo>
+            <S.FriendName>{friend.name}</S.FriendName>
+            <S.FriendStatus>온라인</S.FriendStatus>
+          </S.FriendInfo>
         </S.FriendItem>
       ))}
     </S.FriendsList>

--- a/src/frontend/src/components/friend/FriendsList/index.tsx
+++ b/src/frontend/src/components/friend/FriendsList/index.tsx
@@ -17,7 +17,7 @@ const FriendsList = () => {
                 <S.FriendStatusMark $isOnline={true} />
               </S.FriendProfileImage>
               <S.FriendInfo>
-                <S.FriendName>{friend.name}</S.FriendName>
+                <S.FriendNickname>{friend.nickname}</S.FriendNickname>
                 <S.FriendStatus>온라인</S.FriendStatus>
               </S.FriendInfo>
             </S.FriendItem>

--- a/src/frontend/src/components/friend/FriendsList/styles.ts
+++ b/src/frontend/src/components/friend/FriendsList/styles.ts
@@ -65,7 +65,7 @@ export const FriendInfo = styled.div`
   min-width: 0;
 `;
 
-export const FriendName = styled(BodyMediumText)`
+export const FriendNickname = styled(BodyMediumText)`
   overflow: hidden;
   color: ${({ theme }) => theme.colors.white};
   text-overflow: ellipsis;

--- a/src/frontend/src/components/friend/FriendsList/styles.ts
+++ b/src/frontend/src/components/friend/FriendsList/styles.ts
@@ -25,6 +25,7 @@ export const FriendItem = styled.li`
   align-items: center;
 
   height: 6.2rem;
+  padding: 0 0.8rem;
   border-top: 0.1rem solid ${({ theme }) => theme.colors.dark[500]};
   border-radius: 0.4rem;
 
@@ -74,4 +75,18 @@ export const FriendNickname = styled(BodyMediumText)`
 
 export const FriendStatus = styled(ChipText)`
   color: ${({ theme }) => theme.colors.dark[300]};
+`;
+
+export const IconContainer = styled.div`
+  display: flex;
+  padding: 0 0.8rem;
+`;
+
+export const IconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 3.2rem;
+  height: 3.2rem;
 `;

--- a/src/frontend/src/components/friend/FriendsList/styles.ts
+++ b/src/frontend/src/components/friend/FriendsList/styles.ts
@@ -38,6 +38,7 @@ export const FriendProfileImage = styled.div<{ $imageUrl: string }>`
 
   width: 3.2rem;
   height: 3.2rem;
+  margin-right: 1.2rem;
   border-radius: 50%;
 
   background-color: ${({ theme }) => theme.colors.white};
@@ -57,11 +58,14 @@ export const FriendStatusMark = styled.div<{ $isOnline: boolean }>`
   background-color: ${({ $isOnline }) => ($isOnline ? 'green' : 'black')};
 `;
 
+export const FriendInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
 export const FriendName = styled(BodyMediumText)`
   overflow: hidden;
-
-  padding-left: 0.8rem;
-
   color: ${({ theme }) => theme.colors.white};
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/frontend/src/components/friend/FriendsList/styles.ts
+++ b/src/frontend/src/components/friend/FriendsList/styles.ts
@@ -62,6 +62,7 @@ export const FriendInfo = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  min-width: 0;
 `;
 
 export const FriendName = styled(BodyMediumText)`

--- a/src/frontend/src/components/friend/FriendsList/styles.ts
+++ b/src/frontend/src/components/friend/FriendsList/styles.ts
@@ -61,7 +61,7 @@ export const FriendStatusMark = styled.div<{ $isOnline: boolean }>`
 export const FriendInfo = styled.div`
   display: flex;
   flex-direction: column;
-  width: 100%;
+  flex-grow: 1;
 `;
 
 export const FriendName = styled(BodyMediumText)`

--- a/src/frontend/src/components/friend/FriendsList/styles.ts
+++ b/src/frontend/src/components/friend/FriendsList/styles.ts
@@ -55,7 +55,7 @@ export const FriendStatusMark = styled.div<{ $isOnline: boolean }>`
   border: 0.1rem solid ${({ theme }) => theme.colors.dark[400]};
   border-radius: 50%;
 
-  background-color: ${({ $isOnline }) => ($isOnline ? 'green' : 'black')};
+  background-color: ${({ theme, $isOnline }) => ($isOnline ? theme.colors.online : theme.colors.black)};
 `;
 
 export const FriendInfo = styled.div`

--- a/src/frontend/src/components/friend/PendingFriendsList/hooks/useGetReceivedRequests.ts
+++ b/src/frontend/src/components/friend/PendingFriendsList/hooks/useGetReceivedRequests.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getReceivedRequest } from '@/api/friends';
 
-const useReceivedRequests = () => {
+const useGetReceivedRequests = () => {
   const result = useQuery({ queryKey: ['receivedRequests'], queryFn: getReceivedRequest });
 
   return {
@@ -11,4 +11,4 @@ const useReceivedRequests = () => {
   };
 };
 
-export default useReceivedRequests;
+export default useGetReceivedRequests;

--- a/src/frontend/src/components/friend/PendingFriendsList/hooks/useGetSentRequests.ts
+++ b/src/frontend/src/components/friend/PendingFriendsList/hooks/useGetSentRequests.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getSentRequest } from '@/api/friends';
 
-const useSentRequests = () => {
+const useGetSentRequests = () => {
   const result = useQuery({ queryKey: ['sentRequests'], queryFn: getSentRequest });
 
   return {
@@ -11,4 +11,4 @@ const useSentRequests = () => {
   };
 };
 
-export default useSentRequests;
+export default useGetSentRequests;

--- a/src/frontend/src/components/friend/PendingFriendsList/hooks/useHandleFriendRequest.ts
+++ b/src/frontend/src/components/friend/PendingFriendsList/hooks/useHandleFriendRequest.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { postAcceptRequest, postRejectRequest } from '@/api/friends';
+
+const useHandleFriendRequest = () => {
+  const queryClient = useQueryClient();
+
+  const acceptRequestMutation = useMutation({
+    mutationKey: ['acceptRequest'],
+    mutationFn: postAcceptRequest,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['friendsList'] });
+      queryClient.invalidateQueries({ queryKey: ['receivedRequests'] });
+    },
+  });
+
+  const rejectRequestMutation = useMutation({
+    mutationKey: ['rejectRequest'],
+    mutationFn: postRejectRequest,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['receivedRequests'] });
+    },
+  });
+
+  return { acceptRequestMutation, rejectRequestMutation };
+};
+
+export default useHandleFriendRequest;

--- a/src/frontend/src/components/friend/PendingFriendsList/hooks/useHandleFriendRequest.ts
+++ b/src/frontend/src/components/friend/PendingFriendsList/hooks/useHandleFriendRequest.ts
@@ -3,17 +3,22 @@ import { useState } from 'react';
 
 import { postAcceptRequest, postRejectRequest } from '@/api/friends';
 
+import usePostDirect from '../../CreateDirectMessageModal/hooks/usePostDirect';
+
 const useHandleFriendRequest = () => {
   const queryClient = useQueryClient();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { createDirectMessage } = usePostDirect();
 
   const acceptRequestMutation = useMutation({
     mutationKey: ['acceptRequest'],
     mutationFn: postAcceptRequest,
-    onSuccess: () => {
+    onSuccess: (_, params) => {
       queryClient.invalidateQueries({ queryKey: ['friendsList'] });
       queryClient.invalidateQueries({ queryKey: ['receivedRequests'] });
       setErrorMessage(null);
+
+      if (params.friendId) createDirectMessage([params.friendId]);
     },
     onError: () => {
       setErrorMessage('요청 수락에 실패했어요. 다시 시도해 주세요.');

--- a/src/frontend/src/components/friend/PendingFriendsList/hooks/useHandleFriendRequest.ts
+++ b/src/frontend/src/components/friend/PendingFriendsList/hooks/useHandleFriendRequest.ts
@@ -1,9 +1,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
 
 import { postAcceptRequest, postRejectRequest } from '@/api/friends';
 
 const useHandleFriendRequest = () => {
   const queryClient = useQueryClient();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const acceptRequestMutation = useMutation({
     mutationKey: ['acceptRequest'],
@@ -11,6 +13,10 @@ const useHandleFriendRequest = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['friendsList'] });
       queryClient.invalidateQueries({ queryKey: ['receivedRequests'] });
+      setErrorMessage(null);
+    },
+    onError: () => {
+      setErrorMessage('요청 수락에 실패했어요. 다시 시도해 주세요.');
     },
   });
 
@@ -19,10 +25,14 @@ const useHandleFriendRequest = () => {
     mutationFn: postRejectRequest,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['receivedRequests'] });
+      setErrorMessage(null);
+    },
+    onError: () => {
+      setErrorMessage('요청 거절에 실패했어요. 다시 시도해 주세요.');
     },
   });
 
-  return { acceptRequestMutation, rejectRequestMutation };
+  return { acceptRequestMutation, rejectRequestMutation, errorMessage };
 };
 
 export default useHandleFriendRequest;

--- a/src/frontend/src/components/friend/PendingFriendsList/hooks/useReceivedRequests.ts
+++ b/src/frontend/src/components/friend/PendingFriendsList/hooks/useReceivedRequests.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getReceivedRequest } from '@/api/friends';
+
+const useReceivedRequests = () => {
+  const result = useQuery({ queryKey: ['receivedRequests'], queryFn: getReceivedRequest });
+
+  return {
+    receivedRequests: result.data,
+    ...result,
+  };
+};
+
+export default useReceivedRequests;

--- a/src/frontend/src/components/friend/PendingFriendsList/hooks/useSentRequests.ts
+++ b/src/frontend/src/components/friend/PendingFriendsList/hooks/useSentRequests.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getSentRequest } from '@/api/friends';
+
+const useSentRequests = () => {
+  const result = useQuery({ queryKey: ['sentRequests'], queryFn: getSentRequest });
+
+  return {
+    sentRequests: result.data,
+    ...result,
+  };
+};
+
+export default useSentRequests;

--- a/src/frontend/src/components/friend/PendingFriendsList/index.tsx
+++ b/src/frontend/src/components/friend/PendingFriendsList/index.tsx
@@ -27,7 +27,7 @@ const PendingFriendsList = () => {
                 <S.FriendItem key={friend.userId}>
                   <S.FriendInfoContainer>
                     <S.FriendProfileImage $imageUrl={''} />
-                    <S.FriendName>{friend.nickname}</S.FriendName>
+                    <S.FriendNickname>{friend.nickname}</S.FriendNickname>
                   </S.FriendInfoContainer>
                   <S.ButtonContainer>
                     <S.AcceptButton
@@ -59,7 +59,7 @@ const PendingFriendsList = () => {
               <S.FriendItem key={friend.userId}>
                 <S.FriendInfoContainer>
                   <S.FriendProfileImage $imageUrl={''} />
-                  <S.FriendName>{friend.userId}</S.FriendName>
+                  <S.FriendNickname>{friend.nickname}</S.FriendNickname>
                 </S.FriendInfoContainer>
               </S.FriendItem>
             ))}

--- a/src/frontend/src/components/friend/PendingFriendsList/index.tsx
+++ b/src/frontend/src/components/friend/PendingFriendsList/index.tsx
@@ -1,52 +1,78 @@
-import { Friend } from '../FriendsList';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { getReceivedRequest, getSentRequest, postAcceptRequest, postRejectRequest } from '@/api/friends';
 
 import * as S from './styles';
 
-const friends: Friend[] = [
-  {
-    name: '친구1',
-    profileImageUrl: '',
-    isOnline: true,
-  },
-  {
-    name: '친구2',
-    profileImageUrl: '',
-    isOnline: true,
-  },
-];
-
+// TODO: 요청 실패 시 에러 메시지
 const PendingFriendsList = () => {
-  // TODO: 받은 친구 및 보낸 친구 요청 리스트 보여주기
-  // TODO: 받은 친구 요청인 경우 수락 및 거절 로직 구현
-  // TODO: 보낸 친구 요청인 경우 요청 취소 로직 구현
-  // 현재는 받은 친구 요청 UI만 구현
+  const queryClient = useQueryClient();
+  const { data: receivedRequests } = useQuery({ queryKey: ['receivedRequests'], queryFn: getReceivedRequest });
+  const { data: sentRequests } = useQuery({ queryKey: ['sentRequests'], queryFn: getSentRequest });
 
-  const handleAcceptButtonClick = () => {
-    console.log('친구 요청 수락');
+  const acceptRequestMutation = useMutation({
+    mutationKey: ['acceptRequest'],
+    mutationFn: postAcceptRequest,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['friendsList'] });
+      queryClient.invalidateQueries({ queryKey: ['receivedRequests'] });
+    },
+  });
+
+  const rejectRequestMutation = useMutation({
+    mutationKey: ['rejectRequest'],
+    mutationFn: postRejectRequest,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['receivedRequests'] });
+    },
+  });
+
+  const handleAcceptButtonClick = (friendId: string) => {
+    acceptRequestMutation.mutate({ friendId });
   };
 
-  const handleRejectButtonClick = () => {
-    console.log('친구 요청 거절');
+  const handleRejectButtonClick = (friendId: string) => {
+    rejectRequestMutation.mutate({ friendId });
   };
 
   return (
-    <S.FriendsList>
-      <S.FriendCount>대기 중인 친구 - {friends.length}명</S.FriendCount>
-      {friends.map((friend, index) => (
-        <S.FriendItem key={`${friend.name}_${index}`}>
-          <S.FriendInfoContainer>
-            <S.FriendProfileImage $imageUrl={friend.profileImageUrl}>
-              <S.FriendStatusMark $isOnline={friend.isOnline} />
-            </S.FriendProfileImage>
-            <S.FriendName>{friend.name}</S.FriendName>
-          </S.FriendInfoContainer>
-          <S.ButtonContainer>
-            <S.AcceptButton onClick={handleAcceptButtonClick}>수락하기</S.AcceptButton>
-            <S.RejectButton onClick={handleRejectButtonClick}>거절하기</S.RejectButton>
-          </S.ButtonContainer>
-        </S.FriendItem>
-      ))}
-    </S.FriendsList>
+    <S.PendingFriendsListContainer>
+      {receivedRequests && (
+        <>
+          <S.FriendsList>
+            <S.FriendCount>받은 요청 - {receivedRequests.length}건</S.FriendCount>
+            {receivedRequests.map((friend) => (
+              <S.FriendItem key={friend.id}>
+                <S.FriendInfoContainer>
+                  <S.FriendProfileImage $imageUrl={''} />
+                  <S.FriendName>{friend.id}</S.FriendName>
+                </S.FriendInfoContainer>
+                <S.ButtonContainer>
+                  <S.AcceptButton onClick={() => handleAcceptButtonClick(friend.requestedBy)}>수락하기</S.AcceptButton>
+                  <S.RejectButton onClick={() => handleRejectButtonClick(friend.requestedBy)}>거절하기</S.RejectButton>
+                </S.ButtonContainer>
+              </S.FriendItem>
+            ))}
+          </S.FriendsList>
+          {receivedRequests.length > 0 && <S.Divider />}
+        </>
+      )}
+      {sentRequests && (
+        <>
+          <S.FriendsList>
+            <S.FriendCount>보낸 요청 - {sentRequests.length}건</S.FriendCount>
+            {sentRequests.map((friend) => (
+              <S.FriendItem key={friend.id}>
+                <S.FriendInfoContainer>
+                  <S.FriendProfileImage $imageUrl={''} />
+                  <S.FriendName>{friend.id}</S.FriendName>
+                </S.FriendInfoContainer>
+              </S.FriendItem>
+            ))}
+          </S.FriendsList>
+        </>
+      )}
+    </S.PendingFriendsListContainer>
   );
 };
 

--- a/src/frontend/src/components/friend/PendingFriendsList/index.tsx
+++ b/src/frontend/src/components/friend/PendingFriendsList/index.tsx
@@ -1,31 +1,14 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-
-import { getReceivedRequest, getSentRequest, postAcceptRequest, postRejectRequest } from '@/api/friends';
-
+import useHandleFriendRequest from './hooks/useHandleFriendRequest';
+import useReceivedRequests from './hooks/useReceivedRequests';
+import useSentRequests from './hooks/useSentRequests';
 import * as S from './styles';
 
 // TODO: 요청 실패 시 에러 메시지
+// LOCAL_TODO: query, mutation 분리
 const PendingFriendsList = () => {
-  const queryClient = useQueryClient();
-  const { data: receivedRequests } = useQuery({ queryKey: ['receivedRequests'], queryFn: getReceivedRequest });
-  const { data: sentRequests } = useQuery({ queryKey: ['sentRequests'], queryFn: getSentRequest });
-
-  const acceptRequestMutation = useMutation({
-    mutationKey: ['acceptRequest'],
-    mutationFn: postAcceptRequest,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['friendsList'] });
-      queryClient.invalidateQueries({ queryKey: ['receivedRequests'] });
-    },
-  });
-
-  const rejectRequestMutation = useMutation({
-    mutationKey: ['rejectRequest'],
-    mutationFn: postRejectRequest,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['receivedRequests'] });
-    },
-  });
+  const { receivedRequests } = useReceivedRequests();
+  const { sentRequests } = useSentRequests();
+  const { acceptRequestMutation, rejectRequestMutation } = useHandleFriendRequest();
 
   const handleAcceptButtonClick = (friendId: string) => {
     acceptRequestMutation.mutate({ friendId });

--- a/src/frontend/src/components/friend/PendingFriendsList/index.tsx
+++ b/src/frontend/src/components/friend/PendingFriendsList/index.tsx
@@ -24,21 +24,21 @@ const PendingFriendsList = () => {
             <S.FriendCount>받은 요청 - {receivedRequests.length}건</S.FriendCount>
             {receivedRequests.map((friend) => (
               <>
-                <S.FriendItem key={friend.id}>
+                <S.FriendItem key={friend.userId}>
                   <S.FriendInfoContainer>
                     <S.FriendProfileImage $imageUrl={''} />
-                    <S.FriendName>{friend.id}</S.FriendName>
+                    <S.FriendName>{friend.nickname}</S.FriendName>
                   </S.FriendInfoContainer>
                   <S.ButtonContainer>
                     <S.AcceptButton
                       $isPending={acceptRequestMutation.isPending}
-                      onClick={() => handleAcceptButtonClick(friend.requestedBy)}
+                      onClick={() => handleAcceptButtonClick(friend.userId)}
                     >
                       {acceptRequestMutation.isPending ? '처리 중...' : '수락하기'}
                     </S.AcceptButton>
                     <S.RejectButton
                       $isPending={rejectRequestMutation.isPending}
-                      onClick={() => handleRejectButtonClick(friend.requestedBy)}
+                      onClick={() => handleRejectButtonClick(friend.userId)}
                     >
                       {rejectRequestMutation.isPending ? '처리 중...' : '거절하기'}
                     </S.RejectButton>
@@ -56,10 +56,10 @@ const PendingFriendsList = () => {
           <S.FriendsList>
             <S.FriendCount>보낸 요청 - {sentRequests.length}건</S.FriendCount>
             {sentRequests.map((friend) => (
-              <S.FriendItem key={friend.id}>
+              <S.FriendItem key={friend.userId}>
                 <S.FriendInfoContainer>
                   <S.FriendProfileImage $imageUrl={''} />
-                  <S.FriendName>{friend.id}</S.FriendName>
+                  <S.FriendName>{friend.userId}</S.FriendName>
                 </S.FriendInfoContainer>
               </S.FriendItem>
             ))}

--- a/src/frontend/src/components/friend/PendingFriendsList/index.tsx
+++ b/src/frontend/src/components/friend/PendingFriendsList/index.tsx
@@ -1,11 +1,11 @@
+import useGetReceivedRequests from './hooks/useGetReceivedRequests';
+import useGetSentRequests from './hooks/useGetSentRequests';
 import useHandleFriendRequest from './hooks/useHandleFriendRequest';
-import useReceivedRequests from './hooks/useReceivedRequests';
-import useSentRequests from './hooks/useSentRequests';
 import * as S from './styles';
 
 const PendingFriendsList = () => {
-  const { receivedRequests } = useReceivedRequests();
-  const { sentRequests } = useSentRequests();
+  const { receivedRequests } = useGetReceivedRequests();
+  const { sentRequests } = useGetSentRequests();
   const { acceptRequestMutation, rejectRequestMutation, errorMessage } = useHandleFriendRequest();
 
   const handleAcceptButtonClick = (friendId: string) => {

--- a/src/frontend/src/components/friend/PendingFriendsList/index.tsx
+++ b/src/frontend/src/components/friend/PendingFriendsList/index.tsx
@@ -3,12 +3,10 @@ import useReceivedRequests from './hooks/useReceivedRequests';
 import useSentRequests from './hooks/useSentRequests';
 import * as S from './styles';
 
-// TODO: 요청 실패 시 에러 메시지
-// LOCAL_TODO: query, mutation 분리
 const PendingFriendsList = () => {
   const { receivedRequests } = useReceivedRequests();
   const { sentRequests } = useSentRequests();
-  const { acceptRequestMutation, rejectRequestMutation } = useHandleFriendRequest();
+  const { acceptRequestMutation, rejectRequestMutation, errorMessage } = useHandleFriendRequest();
 
   const handleAcceptButtonClick = (friendId: string) => {
     acceptRequestMutation.mutate({ friendId });
@@ -25,16 +23,29 @@ const PendingFriendsList = () => {
           <S.FriendsList>
             <S.FriendCount>받은 요청 - {receivedRequests.length}건</S.FriendCount>
             {receivedRequests.map((friend) => (
-              <S.FriendItem key={friend.id}>
-                <S.FriendInfoContainer>
-                  <S.FriendProfileImage $imageUrl={''} />
-                  <S.FriendName>{friend.id}</S.FriendName>
-                </S.FriendInfoContainer>
-                <S.ButtonContainer>
-                  <S.AcceptButton onClick={() => handleAcceptButtonClick(friend.requestedBy)}>수락하기</S.AcceptButton>
-                  <S.RejectButton onClick={() => handleRejectButtonClick(friend.requestedBy)}>거절하기</S.RejectButton>
-                </S.ButtonContainer>
-              </S.FriendItem>
+              <>
+                <S.FriendItem key={friend.id}>
+                  <S.FriendInfoContainer>
+                    <S.FriendProfileImage $imageUrl={''} />
+                    <S.FriendName>{friend.id}</S.FriendName>
+                  </S.FriendInfoContainer>
+                  <S.ButtonContainer>
+                    <S.AcceptButton
+                      $isPending={acceptRequestMutation.isPending}
+                      onClick={() => handleAcceptButtonClick(friend.requestedBy)}
+                    >
+                      {acceptRequestMutation.isPending ? '처리 중...' : '수락하기'}
+                    </S.AcceptButton>
+                    <S.RejectButton
+                      $isPending={rejectRequestMutation.isPending}
+                      onClick={() => handleRejectButtonClick(friend.requestedBy)}
+                    >
+                      {rejectRequestMutation.isPending ? '처리 중...' : '거절하기'}
+                    </S.RejectButton>
+                  </S.ButtonContainer>
+                </S.FriendItem>
+                {errorMessage && <S.ErrorMessage>{errorMessage}</S.ErrorMessage>}
+              </>
             ))}
           </S.FriendsList>
           {receivedRequests.length > 0 && <S.Divider />}

--- a/src/frontend/src/components/friend/PendingFriendsList/styles.ts
+++ b/src/frontend/src/components/friend/PendingFriendsList/styles.ts
@@ -66,10 +66,10 @@ export const FriendStatusMark = styled.div<{ $isOnline: boolean }>`
   border: 0.1rem solid ${({ theme }) => theme.colors.dark[400]};
   border-radius: 50%;
 
-  background-color: ${({ $isOnline }) => ($isOnline ? 'green' : 'black')};
+  background-color: ${({ theme, $isOnline }) => ($isOnline ? theme.colors.online : theme.colors.black)};
 `;
 
-export const FriendName = styled(BodyMediumText)`
+export const FriendNickname = styled(BodyMediumText)`
   overflow: hidden;
 
   padding-left: 0.8rem;

--- a/src/frontend/src/components/friend/PendingFriendsList/styles.ts
+++ b/src/frontend/src/components/friend/PendingFriendsList/styles.ts
@@ -2,6 +2,12 @@ import styled from 'styled-components';
 
 import { BodyMediumText, ChipText } from '@/styles/Typography';
 
+export const PendingFriendsListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
 export const FriendsList = styled.ul`
   display: flex;
   flex-direction: column;
@@ -102,4 +108,10 @@ export const RejectButton = styled.button`
   color: ${({ theme }) => theme.colors.white};
 
   background-color: ${({ theme }) => theme.colors.red};
+`;
+
+export const Divider = styled.hr`
+  margin: 0 2rem 0 3rem;
+  border: 0;
+  border-top: 0.1rem solid ${({ theme }) => theme.colors.dark[500]};
 `;

--- a/src/frontend/src/components/friend/PendingFriendsList/styles.ts
+++ b/src/frontend/src/components/friend/PendingFriendsList/styles.ts
@@ -32,6 +32,7 @@ export const FriendItem = styled.li`
   justify-content: space-between;
 
   height: 6.2rem;
+  padding: 0 0.8rem;
   border-top: 0.1rem solid ${({ theme }) => theme.colors.dark[500]};
   border-radius: 0.4rem;
 

--- a/src/frontend/src/components/friend/PendingFriendsList/styles.ts
+++ b/src/frontend/src/components/friend/PendingFriendsList/styles.ts
@@ -88,7 +88,10 @@ export const ButtonContainer = styled.div`
   gap: 0.5rem;
 `;
 
-export const AcceptButton = styled.button`
+export const AcceptButton = styled.button<{ $isPending: boolean }>`
+  pointer-events: ${({ $isPending }) => ($isPending ? 'none' : 'auto')};
+  cursor: ${({ $isPending }) => ($isPending ? 'not-allowed' : 'pointer')};
+
   width: 8rem;
   height: 3.2rem;
   border-radius: 0.4rem;
@@ -99,7 +102,10 @@ export const AcceptButton = styled.button`
   background-color: ${({ theme }) => theme.colors.green};
 `;
 
-export const RejectButton = styled.button`
+export const RejectButton = styled.button<{ $isPending: boolean }>`
+  pointer-events: ${({ $isPending }) => ($isPending ? 'none' : 'auto')};
+  cursor: ${({ $isPending }) => ($isPending ? 'not-allowed' : 'pointer')};
+
   width: 8rem;
   height: 3.2rem;
   border-radius: 0.4rem;
@@ -114,4 +120,10 @@ export const Divider = styled.hr`
   margin: 0 2rem 0 3rem;
   border: 0;
   border-top: 0.1rem solid ${({ theme }) => theme.colors.dark[500]};
+`;
+
+export const ErrorMessage = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  color: ${({ theme }) => theme.colors.red};
 `;

--- a/src/frontend/src/components/guild/GuildCategoriesList/index.tsx
+++ b/src/frontend/src/components/guild/GuildCategoriesList/index.tsx
@@ -5,7 +5,7 @@ import { TbPlus } from 'react-icons/tb';
 import { GuildChannelInfo, useChannelInfoStore } from '@/stores/channelInfo';
 import { useGuildInfoStore } from '@/stores/guildInfo';
 import useModalStore from '@/stores/modalStore';
-import { BodyMediumText, BodyRegularText } from '@/styles/Typography';
+import { BodyMediumText, BodyRegularText, ChipText } from '@/styles/Typography';
 import { CategoryDataResult, ChannelResult, ChannelType } from '@/types/guilds';
 
 import CreateChannelModal from '../CreateChannelModal';
@@ -34,7 +34,7 @@ const GuildCategoriesList = ({ categories, channels }: CategoriesListProps) => {
       {categories?.map((category) => (
         <S.Category key={category.categoryId}>
           <S.CategoryName>
-            <BodyMediumText>{category.name}</BodyMediumText>
+            <ChipText>{category.name}</ChipText>
             <TbPlus size={18} onClick={() => handleOpenModal(category.categoryId, guildId)} />
           </S.CategoryName>
           <S.Channels>

--- a/src/frontend/src/constants/endPoint.ts
+++ b/src/frontend/src/constants/endPoint.ts
@@ -10,6 +10,18 @@ export const endPoint = {
     POST_SIGN_IN: '/users/sign-in',
   },
 
+  friends: {
+    // Friends API
+    DELETE_FRIEND: (friendId: string) => `users/friends/${friendId}`,
+    GET_FRIENDS: '/users/friends',
+    GET_SENT_REQUESTS: '/users/friends/sent',
+    GET_RECEIVED_REQUESTS: 'users/friends/received',
+    GET_FRIENDS_LIST: 'users/friends/list',
+    POST_REQUEST: (toUserId: string) => `users/friends/request/${toUserId}`,
+    POST_REJECT_REQUEST: (friendId: string) => `users/friends/reject/${friendId}`,
+    POST_ACCEPT_REQUEST: (friendId: string) => `users/friends/accept/${friendId}`,
+  },
+
   guilds: {
     // Guild Category API
     DELETE_CATEGORY: (guildId: string, categoryId: string) => `/guilds/category/${guildId}/${categoryId}`,

--- a/src/frontend/src/constants/endPoint.ts
+++ b/src/frontend/src/constants/endPoint.ts
@@ -2,6 +2,7 @@ export const endPoint = {
   users: {
     // User API
     DELETE_USER: '/users/auth',
+    GET_USER_INFO: '/users/info',
     PATCH_USER_INFO: '/users/info',
     PATCH_DEVICE_TOKEN: '/users/device-token',
     POST_VALIDATION_EMAIL: '/users/validation/email',

--- a/src/frontend/src/constants/endPoint.ts
+++ b/src/frontend/src/constants/endPoint.ts
@@ -5,6 +5,8 @@ export const endPoint = {
     GET_USER_INFO: '/users/info',
     PATCH_USER_INFO: '/users/info',
     PATCH_DEVICE_TOKEN: '/users/device-token',
+
+    // Login, Registration API
     POST_VALIDATION_EMAIL: '/users/validation/email',
     POST_AUTHENTICATION_CODE: '/users/validation/authentication-code',
     POST_SIGN_UP: '/users/sign-up',
@@ -13,14 +15,16 @@ export const endPoint = {
 
   friends: {
     // Friends API
-    DELETE_FRIEND: (friendId: string) => `users/friends/${friendId}`,
+    DELETE_FRIEND: (friendId: string) => `/users/friends/${friendId}`,
     GET_FRIENDS: '/users/friends',
+    GET_FRIENDS_LIST: '/users/friends/list',
+
+    // Friends Request API
     GET_SENT_REQUESTS: '/users/friends/sent',
-    GET_RECEIVED_REQUESTS: 'users/friends/received',
-    GET_FRIENDS_LIST: 'users/friends/list',
-    POST_REQUEST: (toUserId: string) => `users/friends/request/${toUserId}`,
-    POST_REJECT_REQUEST: (friendId: string) => `users/friends/reject/${friendId}`,
-    POST_ACCEPT_REQUEST: (friendId: string) => `users/friends/accept/${friendId}`,
+    GET_RECEIVED_REQUESTS: '/users/friends/received',
+    POST_REQUEST: (toUserId: string) => `/users/friends/request/${toUserId}`,
+    POST_REJECT_REQUEST: (friendId: string) => `/users/friends/reject/${friendId}`,
+    POST_ACCEPT_REQUEST: (friendId: string) => `/users/friends/accept/${friendId}`,
   },
 
   guilds: {
@@ -48,5 +52,11 @@ export const endPoint = {
     REJECT_GUILD_INVITATION: (guildId: string) => `/guilds/guilds/${guildId}/invitations/reject`,
     ACCEPT_GUILD_INVITATION: (guildId: string) => `/guilds/guilds/${guildId}/invitations/accept`,
     SEND_INVITATION: (guildId: string) => `/guilds/guilds/${guildId}/invitations`,
+  },
+
+  directMessages: {
+    // Direct Message API
+    GET_DIRECTS: '/guilds/direct',
+    POST_DIRECT: '/guilds/direct',
   },
 };

--- a/src/frontend/src/pages/FriendsPage/components/CategorySection/index.tsx
+++ b/src/frontend/src/pages/FriendsPage/components/CategorySection/index.tsx
@@ -11,15 +11,7 @@ const CategorySection = () => {
   return (
     <S.CategorySectionContainer>
       <S.CategoryItemWrapper>{guildId ? <GuildCategory /> : <DirectMessageCategory />}</S.CategoryItemWrapper>
-      <UserProfile
-        userName="Fe"
-        userImageUrl=""
-        isOnline={true}
-        isMicOn={true}
-        isHeadsetOn={true}
-        handleMicToggle={() => {}}
-        handleHeadsetToggle={() => {}}
-      />
+      <UserProfile isMicOn={true} isHeadsetOn={true} handleMicToggle={() => {}} handleHeadsetToggle={() => {}} />
     </S.CategorySectionContainer>
   );
 };

--- a/src/frontend/src/pages/FriendsPage/components/UserProfile/hooks/useGetUserInfo.ts
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfile/hooks/useGetUserInfo.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import { getUserInfo } from '@/api/users';
+import { useUserInfoStore } from '@/stores/userInfo';
+
+const useGetUserInfo = () => {
+  const { setUserInfo, clearUserInfo } = useUserInfoStore();
+
+  const queryResult = useQuery({
+    queryKey: ['userInfo'],
+    queryFn: getUserInfo,
+    staleTime: 14 * 24 * 60 * 60 * 1000,
+  });
+
+  useEffect(() => {
+    if (queryResult.data) setUserInfo({ userId: queryResult.data.result.userId });
+  }, [queryResult.data, setUserInfo]);
+
+  useEffect(() => {
+    if (queryResult.isError) clearUserInfo();
+  }, [queryResult.isError, clearUserInfo]);
+
+  return { userInfo: queryResult.data?.result, ...queryResult };
+};
+
+export default useGetUserInfo;

--- a/src/frontend/src/pages/FriendsPage/components/UserProfile/hooks/useGetUserInfo.ts
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfile/hooks/useGetUserInfo.ts
@@ -5,7 +5,7 @@ import { getUserInfo } from '@/api/users';
 import { useUserInfoStore } from '@/stores/userInfo';
 
 const useGetUserInfo = () => {
-  const { setUserInfo, clearUserInfo } = useUserInfoStore();
+  const { userInfo, setUserInfo, clearUserInfo } = useUserInfoStore();
 
   const queryResult = useQuery({
     queryKey: ['userInfo'],
@@ -14,8 +14,11 @@ const useGetUserInfo = () => {
   });
 
   useEffect(() => {
-    if (queryResult.data) setUserInfo({ userId: queryResult.data.result.userId });
-  }, [queryResult.data, setUserInfo]);
+    if (queryResult.data) {
+      const newUserId = queryResult.data.result.userId;
+      if (newUserId !== userInfo?.userId) setUserInfo({ userId: queryResult.data.result.userId });
+    }
+  }, [queryResult.data, setUserInfo, userInfo]);
 
   useEffect(() => {
     if (queryResult.isError) clearUserInfo();

--- a/src/frontend/src/pages/FriendsPage/components/UserProfile/index.tsx
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfile/index.tsx
@@ -6,39 +6,32 @@ import useDropdown from '@/hooks/useDropdown';
 
 import UserProfileTab from '../UserProfileTab';
 
+import useGetUserInfo from './hooks/useGetUserInfo';
 import * as S from './styles';
 
+// TODO: 마이크, 헤드셋 전역 상태로 관리
 interface UserProfileProps {
-  userImageUrl: string;
-  userName: string;
-  isOnline: boolean;
   isMicOn: boolean;
   isHeadsetOn: boolean;
   handleMicToggle: () => void;
   handleHeadsetToggle: () => void;
 }
 
-// TODO: props로 받고 있는 정보들을 전역 상태 및 사용자 정보 요청으로 대체
-const UserProfile = ({
-  userImageUrl,
-  userName,
-  isOnline,
-  isMicOn,
-  isHeadsetOn,
-  handleMicToggle,
-  handleHeadsetToggle,
-}: UserProfileProps) => {
+const UserProfile = ({ isMicOn, isHeadsetOn, handleMicToggle, handleHeadsetToggle }: UserProfileProps) => {
   const { isOpened, dropdownRef, toggleDropdown } = useDropdown();
+
+  const { userInfo } = useGetUserInfo();
+  if (!userInfo) return null;
 
   return (
     <S.UserProfileContainer ref={dropdownRef}>
       <S.UserInfoContainer onClick={toggleDropdown}>
-        <S.UserImage $userImageUrl={userImageUrl}>
-          <S.UserStatusMark $isOnline={isOnline} />
+        <S.UserImage $userImageUrl={userInfo.profileImageUrl}>
+          <S.UserStatusMark $isOnline={true} />
         </S.UserImage>
         <S.UserInfo>
-          <S.UserName>{userName}</S.UserName>
-          <S.UserStatus>{isOnline ? '온라인' : '오프라인'}</S.UserStatus>
+          <S.UserName>{userInfo.nickname}</S.UserName>
+          <S.UserStatus>온라인</S.UserStatus>
         </S.UserInfo>
       </S.UserInfoContainer>
       <S.ControlButtonContainer>

--- a/src/frontend/src/pages/FriendsPage/components/UserProfile/styles.ts
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfile/styles.ts
@@ -38,6 +38,8 @@ export const UserImage = styled.div<{ $userImageUrl: string }>`
 
   background-color: ${({ theme }) => theme.colors.white};
   background-image: url(${(props) => props.$userImageUrl});
+  background-repeat: no-repeat;
+  background-size: contain;
 `;
 
 export const UserStatusMark = styled.div<{ $isOnline: boolean }>`

--- a/src/frontend/src/pages/FriendsPage/components/UserProfile/styles.ts
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfile/styles.ts
@@ -52,7 +52,7 @@ export const UserStatusMark = styled.div<{ $isOnline: boolean }>`
   border: 0.1rem solid ${({ theme }) => theme.colors.dark[400]};
   border-radius: 50%;
 
-  background-color: ${({ $isOnline }) => ($isOnline ? 'green' : 'black')};
+  background-color: ${({ theme, $isOnline }) => ($isOnline ? theme.colors.online : theme.colors.black)};
 `;
 
 export const UserInfo = styled.div`

--- a/src/frontend/src/pages/FriendsPage/components/UserProfileTab/components/DeleteAccountConfirmModal/index.tsx
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfileTab/components/DeleteAccountConfirmModal/index.tsx
@@ -1,0 +1,39 @@
+import { useNavigate } from 'react-router-dom';
+
+import { deleteAccount } from '@/api/users';
+import Modal from '@/components/common/Modal';
+import useModalStore from '@/stores/modalStore';
+import { useUserInfoStore } from '@/stores/userInfo';
+
+import * as S from './styles';
+
+const DeleteAccountConfirmModal = () => {
+  const navigate = useNavigate();
+  const { closeAllModal } = useModalStore();
+  const { userInfo } = useUserInfoStore();
+  if (!userInfo) return null;
+
+  const handleDeleteAccount = async () => {
+    try {
+      await deleteAccount({ userId: userInfo.userId });
+      closeAllModal();
+      navigate('/login', { replace: true });
+    } catch (error) {
+      console.error('회원 탈퇴 실패', error);
+    }
+  };
+
+  return (
+    <Modal name="withFooter">
+      <Modal.Content>
+        <S.ConfirmText>정말 계정을 탈퇴하시겠어요?</S.ConfirmText>
+      </Modal.Content>
+      <S.ModalButtonContainer>
+        <S.CancelButton onClick={closeAllModal}>취소</S.CancelButton>
+        <S.DeleteButton onClick={handleDeleteAccount}>탈퇴하기</S.DeleteButton>
+      </S.ModalButtonContainer>
+    </Modal>
+  );
+};
+
+export default DeleteAccountConfirmModal;

--- a/src/frontend/src/pages/FriendsPage/components/UserProfileTab/components/DeleteAccountConfirmModal/styles.ts
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfileTab/components/DeleteAccountConfirmModal/styles.ts
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+import { BodyMediumText } from '@/styles/Typography';
+
+export const ConfirmText = styled(BodyMediumText)`
+  color: ${({ theme }) => theme.colors.white};
+`;
+
+export const ModalButtonContainer = styled.div`
+  display: flex;
+  gap: 1.6rem;
+  align-items: center;
+  justify-content: flex-end;
+
+  height: 7rem;
+  padding: 1.6rem;
+
+  background-color: ${({ theme }) => theme.colors.dark[600]};
+`;
+
+export const CancelButton = styled.button`
+  height: 3.8rem;
+  padding: 0.2rem 1.6rem;
+  color: ${({ theme }) => theme.colors.white};
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+export const DeleteButton = styled.button`
+  height: 3.8rem;
+  padding: 0.2rem 1.6rem;
+  border-radius: 0.4rem;
+
+  color: ${({ theme }) => theme.colors.white};
+
+  background-color: ${({ theme }) => theme.colors.red};
+
+  &:hover {
+    opacity: 0.8;
+  }
+`;

--- a/src/frontend/src/pages/FriendsPage/components/UserProfileTab/hooks/useUserProfileTabElements.tsx
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfileTab/hooks/useUserProfileTabElements.tsx
@@ -1,5 +1,9 @@
 import { useNavigate } from 'react-router-dom';
 
+import useModalStore from '@/stores/modalStore';
+
+import DeleteAccountConfirmModal from '../components/DeleteAccountConfirmModal';
+
 interface MenuItem {
   elementId: string;
   content: string;
@@ -8,6 +12,8 @@ interface MenuItem {
 
 const useUserProfileTabElements = () => {
   const navigate = useNavigate();
+  const { openModal } = useModalStore();
+
   const handleModifyProfile = () => {
     // 추후 정보 수정 모달 구현
     console.log('사용자 정보 수정 메뉴 클릭');
@@ -16,6 +22,10 @@ const useUserProfileTabElements = () => {
   const handleLogout = () => {
     localStorage.removeItem('access_token');
     navigate('/login', { replace: true });
+  };
+
+  const handleDeleteAccount = () => {
+    openModal('withFooter', <DeleteAccountConfirmModal />);
   };
 
   const userProfileTabElements: MenuItem[] = [
@@ -28,6 +38,11 @@ const useUserProfileTabElements = () => {
       elementId: 'logout',
       content: '로그아웃',
       handleClick: handleLogout,
+    },
+    {
+      elementId: 'deleteAccount',
+      content: '회원 탈퇴',
+      handleClick: handleDeleteAccount,
     },
   ];
 

--- a/src/frontend/src/pages/FriendsPage/components/UserProfileTab/hooks/useUserProfileTabElements.tsx
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfileTab/hooks/useUserProfileTabElements.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
 import useModalStore from '@/stores/modalStore';
@@ -11,6 +12,7 @@ interface MenuItem {
 }
 
 const useUserProfileTabElements = () => {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { openModal } = useModalStore();
 
@@ -21,6 +23,9 @@ const useUserProfileTabElements = () => {
 
   const handleLogout = () => {
     localStorage.removeItem('access_token');
+    // staleTime이 설정된 쿼리 삭제
+    queryClient.removeQueries({ queryKey: ['userInfo'] });
+    queryClient.removeQueries({ queryKey: ['friendsList'] });
     navigate('/login', { replace: true });
   };
 

--- a/src/frontend/src/pages/FriendsPage/components/UserProfileTab/index.tsx
+++ b/src/frontend/src/pages/FriendsPage/components/UserProfileTab/index.tsx
@@ -1,5 +1,6 @@
 import useUserProfileTabElements from './hooks/useUserProfileTabElements';
 import * as S from './styles';
+
 const UserProfileTab = () => {
   const { userProfileTabElements } = useUserProfileTabElements();
 

--- a/src/frontend/src/stores/channelInfo.ts
+++ b/src/frontend/src/stores/channelInfo.ts
@@ -18,8 +18,8 @@ interface DMChannelInfo {
 interface ChannelState {
   selectedChannel: GuildChannelInfo | null;
   selectedDMChannel: DMChannelInfo | null;
-  setSelectedChannel: (channel: GuildChannelInfo) => void;
-  setSelectedDMChannel: (channel: DMChannelInfo) => void;
+  setSelectedChannel: (channel: GuildChannelInfo | null) => void;
+  setSelectedDMChannel: (channel: DMChannelInfo | null) => void;
 }
 
 export const useChannelInfoStore = create<ChannelState>()(

--- a/src/frontend/src/stores/userInfo.ts
+++ b/src/frontend/src/stores/userInfo.ts
@@ -11,7 +11,7 @@ interface UserState {
   clearUserInfo: () => void;
 }
 
-export const useChannelInfoStore = create<UserState>()(
+export const useUserInfoStore = create<UserState>()(
   persist(
     (set) => ({
       userInfo: null,

--- a/src/frontend/src/styles/theme.ts
+++ b/src/frontend/src/styles/theme.ts
@@ -16,6 +16,7 @@ const colors = {
   },
   red: '#FF595E',
   green: '#248045',
+  online: '#23A55A',
   blue: '#5765F2',
   link: '#069BE3',
 };

--- a/src/frontend/src/types/directMessages.ts
+++ b/src/frontend/src/types/directMessages.ts
@@ -1,0 +1,35 @@
+interface MemberInfo {
+  userId: string;
+  name: string;
+  nickname: string;
+  profileImageUrl: string;
+  email: string;
+  birth: string;
+}
+
+interface DirectMessageInfo {
+  directId: string;
+  members: {
+    responses: MemberInfo[];
+  };
+}
+
+export interface GetDirectMessagesResponse {
+  httpStatus: number;
+  message: string;
+  time: Date;
+  result: {
+    directResponses: DirectMessageInfo[];
+  };
+}
+
+export interface PostDirectMessageRequest {
+  memberIds: string[];
+}
+
+export interface PostDirectMessageResponse {
+  httpStatus: number;
+  message: string;
+  time: Date;
+  result: DirectMessageInfo;
+}

--- a/src/frontend/src/types/directMessages.ts
+++ b/src/frontend/src/types/directMessages.ts
@@ -1,4 +1,4 @@
-interface MemberInfo {
+interface DirectMessageMemberInfo {
   userId: string;
   name: string;
   nickname: string;
@@ -10,7 +10,7 @@ interface MemberInfo {
 interface DirectMessageInfo {
   directId: string;
   members: {
-    responses: MemberInfo[];
+    responses: DirectMessageMemberInfo[];
   };
 }
 

--- a/src/frontend/src/types/friends.ts
+++ b/src/frontend/src/types/friends.ts
@@ -1,0 +1,49 @@
+// result가 없는 기본 응답
+export interface FriendDefaultResponse {
+  httpStatus: number;
+  message: string;
+  time: Date;
+  result: null;
+}
+
+export type DeleteFriendResponse = FriendDefaultResponse;
+
+export interface GetFriendsResponse {
+  email: string;
+  name: string;
+  nickname: string;
+  profileImgUrl: string;
+  birth: string;
+}
+
+export interface FriendRequest {
+  id: string;
+  userId1: string;
+  userId2: string;
+  requestedBy: string;
+  status: 'PENDING' | 'ACCEPTED' | string;
+}
+
+export interface GetSentRequestsResponse {
+  httpStatus: number;
+  message: string;
+  time: Date;
+  result: {
+    friends: FriendRequest[];
+  };
+}
+
+export type GetReceivedRequestsResponse = GetSentRequestsResponse;
+
+export type GetFriendsListResponse = GetSentRequestsResponse;
+
+export interface PostFriendResponse {
+  httpStatus: number;
+  message: string;
+  time: Date;
+  result: FriendRequest;
+}
+
+export type PostRejectResponse = PostFriendResponse;
+
+export type PostAcceptResponse = PostFriendResponse;

--- a/src/frontend/src/types/friends.ts
+++ b/src/frontend/src/types/friends.ts
@@ -8,13 +8,6 @@ export interface FriendDefaultResponse {
 
 export type DeleteFriendResponse = FriendDefaultResponse;
 
-export interface GetFriendInfoResponse {
-  email: string;
-  name: string;
-  nickname: string;
-  profileImgUrl: string;
-  birth: string;
-}
 export interface FriendInfo {
   userId: string;
   name: string;
@@ -22,6 +15,13 @@ export interface FriendInfo {
   profileImageUrl: string;
   email: string;
   birth: string;
+}
+
+export interface GetFriendInfoResponse {
+  httpStatus: number;
+  message: string;
+  time: Date;
+  result: FriendInfo;
 }
 
 export interface GetSentRequestsResponse {

--- a/src/frontend/src/types/friends.ts
+++ b/src/frontend/src/types/friends.ts
@@ -8,7 +8,7 @@ export interface FriendDefaultResponse {
 
 export type DeleteFriendResponse = FriendDefaultResponse;
 
-export interface GetFriendsResponse {
+export interface GetFriendInfoResponse {
   email: string;
   name: string;
   nickname: string;
@@ -35,15 +35,31 @@ export interface GetSentRequestsResponse {
 
 export type GetReceivedRequestsResponse = GetSentRequestsResponse;
 
-export type GetFriendsListResponse = GetSentRequestsResponse;
+export interface FriendInfo {
+  userId: string;
+  name: string;
+  nickname: string;
+  profileImageUrl: string;
+  email: string;
+  birth: string;
+}
 
-export interface PostFriendResponse {
+export interface GetFriendsListResponse {
+  httpStatus: number;
+  message: string;
+  time: Date;
+  result: {
+    friends: FriendInfo[];
+  };
+}
+
+export interface PostRequestResponse {
   httpStatus: number;
   message: string;
   time: Date;
   result: FriendRequest;
 }
 
-export type PostRejectResponse = PostFriendResponse;
+export type PostRejectResponse = PostRequestResponse;
 
-export type PostAcceptResponse = PostFriendResponse;
+export type PostAcceptResponse = PostRequestResponse;

--- a/src/frontend/src/types/friends.ts
+++ b/src/frontend/src/types/friends.ts
@@ -15,26 +15,6 @@ export interface GetFriendInfoResponse {
   profileImgUrl: string;
   birth: string;
 }
-
-export interface FriendRequest {
-  id: string;
-  userId1: string;
-  userId2: string;
-  requestedBy: string;
-  status: 'PENDING' | 'ACCEPTED' | string;
-}
-
-export interface GetSentRequestsResponse {
-  httpStatus: number;
-  message: string;
-  time: Date;
-  result: {
-    friends: FriendRequest[];
-  };
-}
-
-export type GetReceivedRequestsResponse = GetSentRequestsResponse;
-
 export interface FriendInfo {
   userId: string;
   name: string;
@@ -44,6 +24,18 @@ export interface FriendInfo {
   birth: string;
 }
 
+export interface GetSentRequestsResponse {
+  httpStatus: number;
+  message: string;
+  time: Date;
+  result: {
+    friends: FriendInfo[];
+    status: 'PENDING' | 'ACCEPTED' | 'REJECTED';
+  };
+}
+
+export type GetReceivedRequestsResponse = GetSentRequestsResponse;
+
 export interface GetFriendsListResponse {
   httpStatus: number;
   message: string;
@@ -51,6 +43,14 @@ export interface GetFriendsListResponse {
   result: {
     friends: FriendInfo[];
   };
+}
+
+export interface FriendRequest {
+  id: string;
+  userId1: string;
+  userId2: string;
+  requestedBy: string;
+  status: 'PENDING' | 'ACCEPTED' | 'REJECTED';
 }
 
 export interface PostRequestResponse {

--- a/src/frontend/src/types/users.ts
+++ b/src/frontend/src/types/users.ts
@@ -6,6 +6,8 @@ export interface UserDefaultResponse {
   result: null;
 }
 
+export type DeleteAccountResponse = UserDefaultResponse;
+
 export interface PostLoginRequest {
   email: string;
   password: string;

--- a/src/frontend/src/types/users.ts
+++ b/src/frontend/src/types/users.ts
@@ -46,6 +46,20 @@ export interface PostEmailDuplicateResponse {
   };
 }
 
+export interface GetUserInfoResponse {
+  httpStatus: number;
+  message: string;
+  time: Date;
+  result: {
+    userId: string;
+    name: string;
+    nickname: string;
+    profileImageUrl: string;
+    email: string;
+    birth: string;
+  };
+}
+
 export interface PatchUserInfoRequest {
   name: string;
   nickname: string;

--- a/src/frontend/src/utils/axios.ts
+++ b/src/frontend/src/utils/axios.ts
@@ -11,7 +11,7 @@ export const tokenAxios = axios.create({
 });
 
 tokenAxios.interceptors.request.use((config) => {
-  const token = import.meta.env.VITE_TOKEN;
+  const token = localStorage.getItem('access_token');
 
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;


### PR DESCRIPTION
## 이슈번호
<!-- PR 작성 시 '- Closes #<이슈번호>' 형식으로 이슈를 연결하세요. ex) '- Closes #3' -->
- Closes #89 

## 요약(개요)
- 로그인 한 사용자의 정보 조회 api를 연동했습니다.
  - UserProfile에서 사용자 정보를 요청하고, userId를 전역 상태로 관리합니다.
  - 사용자 정보 api의 staleTime은 현재 access_token의 유효 기간인 2주와 동일하게 설정했습니다.

- 친구 목록, 보낸/받은 친구 요청 목록, 받은 요청에 대한 수락/거절 api를 연동했습니다.
  - 친구 목록은 자주 바뀌는 데이터가 아니므로 staleTime을 10분으로 설정했습니다.
  - 보낸/받은 친구 요청 목록은 실시간성이 중요하므로 매번 fetch합니다. 
  - 받은 요청을 수락/거절하면 친구 요청 목록과 친구 목록 query를 무효화합니다.
  - 받은 요청을 수락하는 경우 해당 친구와의 DM 채팅방을 자동으로 생성합니다.
  - 친구 요청하기 전에 먼저 친구로 등록된 사용자인지, 이미 요청을 보냈거나 받았는지를 확인한 뒤에 친구 검색하고, 성공 시에 요청을 보냅니다.

- DM 목록 조회 및 DM 생성 api를 연동했습니다.
  - DM 생성 모달에서는 최대 9명의 친구를 선택해서 방을 만들 수 있습니다. 생성하면 모달은 닫힙니다.

- 친구 삭제 api를 연동했습니다.
- 계정 탈퇴 api를 연동했습니다.
- 기타 코드 컨벤션 관련 또는 디자인 수정이 있습니다.

## 작업 내용
![image](https://github.com/user-attachments/assets/33962256-2f90-4c90-b2e7-aaead23f6936)
▲ 길드 리스트에서 DM을 선택한 경우

![image](https://github.com/user-attachments/assets/e140b74e-be72-4da7-8e46-9702f626b651)
![image](https://github.com/user-attachments/assets/7ed3e357-2d62-4235-abcc-8a9c7c59e912)
▲ 대기 중(받은, 보낸 친구 요청 목록)인 목록

![image](https://github.com/user-attachments/assets/3e93a8a8-563f-44f0-8af7-79667cb638ca)
▲ DM 생성 모달 

## 집중해서 리뷰해야 하는 부분

## 기타 전달 사항 및 참고 자료(선택)
- 외장 ssd로 파일 옮기다가 작업한 게 전부 날아갈 뻔했네요... 무서워서 일단 PR 먼저 올렸습니다😞
- 친구 검색 시 응답으로 userId를 함께 내려줘야 하는데, api가 수정되는 대로 반영할 예정입니다. -> 반영 완료했습니다