### PR TITLE
[FE] fix: background-image의 url을 import해서 모듈로 수정

### DIFF
--- a/src/frontend/src/components/layout/PublicOnlyLayout/styles.ts
+++ b/src/frontend/src/components/layout/PublicOnlyLayout/styles.ts
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import BackgroundImage from '@/assets/background.svg';
+
 export const LayoutContainer = styled.div`
   position: relative;
   width: 100%;
@@ -15,7 +17,7 @@ export const Background = styled.div`
   width: 100vw;
   height: 100vh;
 
-  background-image: url('/src/assets/background.svg');
+  background-image: url(${BackgroundImage});
   background-repeat: no-repeat;
   background-size: cover;
 `;

--- a/src/frontend/src/pages/LandingPage/styles.ts
+++ b/src/frontend/src/pages/LandingPage/styles.ts
@@ -1,5 +1,8 @@
 import styled from 'styled-components';
 
+import LandingBackgroundImage from '@/assets/landingBackground.png';
+import LandingPreview from '@/assets/landingPreview.webp';
+import LandingStars from '@/assets/landingStars.webp';
 import { BodyRegularText, DisplayText } from '@/styles/Typography';
 
 export const PageContainer = styled.div`
@@ -9,7 +12,7 @@ export const PageContainer = styled.div`
 
   width: 100%;
 
-  background-image: url('/src/assets/landingBackground.png');
+  background-image: url(${LandingBackgroundImage});
   background-repeat: no-repeat;
   background-position: 0 1%;
   background-size: cover;
@@ -25,7 +28,7 @@ export const DescriptionContainer = styled.div`
   padding: 0 4rem;
   padding-top: 10rem;
 
-  background-image: url('/src/assets/landingStars.webp');
+  background-image: url(${LandingStars});
   background-repeat: no-repeat;
   background-size: 90%;
 `;
@@ -56,7 +59,7 @@ export const PreviewImageWrapper = styled.div`
   max-width: 60rem;
   min-height: 50rem;
 
-  background-image: url('/src/assets/landingPreview.webp');
+  background-image: url(${LandingPreview});
   background-repeat: no-repeat;
   background-position: 50%;
   background-size: contain;

--- a/src/frontend/src/pages/LoginPage/styles.ts
+++ b/src/frontend/src/pages/LoginPage/styles.ts
@@ -1,6 +1,7 @@
 import { motion } from 'motion/react';
 import styled from 'styled-components';
 
+import QRCodeAssetImage from '@/assets/qrcode.svg';
 import {
   BodyMediumText,
   BodyRegularText,
@@ -146,7 +147,7 @@ export const QRCodeWrapper = styled.div`
 export const QRCodeImage = styled.div`
   width: 100%;
   height: 100%;
-  background-image: url('/src/assets/qrcode.svg');
+  background-image: url(${QRCodeAssetImage});
   background-size: cover;
 `;
 


### PR DESCRIPTION
## 이슈번호
<!-- PR 작성 시 '- Closes #<이슈번호>' 형식으로 이슈를 연결하세요. ex) '- Closes #3' -->
- Closes #114 

## 요약(개요)
- Vercel로 배포 시, 이미지 주소가 바껴서 `background-image`에서 로컬 asset 경로로 설정했던 이미지들을 불러오지 못하는 문제가 발생했습니다.
- 이미지 경로를 직접 넣지 않고, import 하여 모듈을 넣었습니다.

## 작업 내용
[//]: # (업무 체크리스트를 작성해주세요.)
- [x] background-image url을 import해서 모듈로 수정

## 집중해서 리뷰해야 하는 부분

## 기타 전달 사항 및 참고 자료(선택)